### PR TITLE
Use the alloc api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ binary-format = ["bytecodec", "trackable"]
 [dependencies]
 bitflags = "1"
 bytecodec = { version = "0.4", optional = true }
-libc = "0.2"
 trackable = { version = "0.2", optional = true }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,6 @@ extern crate bitflags;
 #[cfg(feature = "binary-format")]
 #[macro_use]
 extern crate bytecodec;
-extern crate libc;
 #[cfg(test)]
 extern crate rand;
 #[cfg(feature = "binary-format")]

--- a/src/node.rs
+++ b/src/node.rs
@@ -133,7 +133,8 @@ impl<V> Node<V> {
 
         block_size += mem::size_of::<Layout>();
 
-        let layout = Layout::array::<u8>(block_size).expect("Failed to get layout");
+        let layout = Layout::from_size_align(block_size, mem::align_of::<*mut Node<V>>())
+            .expect("Failed to get layout");
         let ptr = unsafe { alloc::alloc(layout) as *mut u8 };
         assert_ne!(ptr, ptr::null_mut());
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -43,6 +43,7 @@ const MAX_LABEL_LEN: usize = 255;
 /// Note that this is a low level building block.
 /// Usually it is recommended to use more high level data structures (e.g., `PatriciaTree`).
 #[derive(Debug)]
+#[repr(C, align(8))]
 pub struct Node<V> {
     // layout:
     //   - flags: u8


### PR DESCRIPTION
I think this is how it's intended to be used, it requires a few extra words of space in `Node`

It was pointed out to me that the library is potentially unsound because there isn't any respect to alignment during allocation (coupled with `ptr::write` which requires alignment). There's quite a lot of unsafe in `Node` also that could be replaced by just regular struct fields too? moving the label to the last field in `Node` might make things a bit easier. What do you think?