### PR TITLE
Use the alloc api and fix alignment issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ binary-format = ["bytecodec", "trackable"]
 [dependencies]
 bitflags = "1"
 bytecodec = { version = "0.4", optional = true }
-libc = "0.2"
 trackable = { version = "0.2", optional = true }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,6 @@ extern crate bitflags;
 #[cfg(feature = "binary-format")]
 #[macro_use]
 extern crate bytecodec;
-extern crate libc;
 #[cfg(test)]
 extern crate rand;
 #[cfg(feature = "binary-format")]

--- a/src/map.rs
+++ b/src/map.rs
@@ -650,6 +650,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn large_map_works() {
         let mut input = (0..10000).map(|i| (i.to_string(), i)).collect::<Vec<_>>();
         input.shuffle(&mut rand::thread_rng());


### PR DESCRIPTION
These commits should fix some of the unsoundness in the library by aligning the pointers in `Node`. The tests now pass Miri.

There is minimal size overhead from aligning the allocations:

```
$ git switch align_allocations

$ cargo build --example insert_lines --release

$ /usr/bin/time -f "# ELAPSED: %E\n# MEMORY: %M" cargo run --example insert_lines --release -- --kind patricia < enwiki-latest-all-titles-in-ns0
# LINES: 9227611
# ELAPSED: 0:59.91
# MEMORY: 421272

$ /usr/bin/time -f "# ELAPSED: %E\n# MEMORY: %M" cargo run --example insert_lines --release -- --kind patricia < googlebooks-eng-all-5gram-20120701-0
# LINES: 9814743
# ELAPSED: 0:30.11
# MEMORY: 386700

$ git checkout 0.1.10

$ cargo build --example insert_lines --release

$ /usr/bin/time -f "# ELAPSED: %E\n# MEMORY: %M" cargo run --example insert_lines --release -- --kind patricia < enwiki-latest-all-titles-in-ns0
# LINES: 9227611
# ELAPSED: 0:56.98
# MEMORY: 421316

$ /usr/bin/time -f "# ELAPSED: %E\n# MEMORY: %M" cargo run --example insert_lines --release -- --kind patricia < googlebooks-eng-all-5gram-20120701-0
# LINES: 9814743
# ELAPSED: 0:31.17
# MEMORY: 386740
```
