### PR TITLE
Implement basic support for custom allocators

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -1,6 +1,5 @@
 //! A node which represents a subtree of a patricia tree.
-use std::alloc::{handle_alloc_error, Layout};
-use std::alloc::{GlobalAlloc, System};
+use std::alloc::{handle_alloc_error, Layout, GlobalAlloc, System};
 use std::marker::PhantomData;
 use std::mem;
 use std::ptr;


### PR DESCRIPTION
Add some way to swap out global `std::alloc::alloc` with custom
implementations of `GlobalAlloc`. Ideally we'd use the unstable
`Allocator` trait for this, but this is good enough to make
`PatriciaTree` work well with bumpalo which is what I care about.

As-is this does not break public API in the same way that adding custom
allocator support to `std::vec::Vec` did not break public API, however a
lot of new API surface is exposed that is not future-proof, i.e. would
have to change again when the `Allocator` trait is stabilized.

There are some ways around this, such as defining your own allocator
trait that people need to manually impl, but I would already be happy if
we move this behind a featureflag named something like
`unstable_custom_alloc` and leave it at that until `Allocator` is truly
stable.