### PR TITLE
Add `PatriciaMap::iter_prefix_mut` and `Node::iter_mut` functions

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -352,13 +352,15 @@ impl<V> PatriciaMap<V> {
         &'a mut self,
         prefix: &'b [u8],
     ) -> impl 'a + Iterator<Item = (Vec<u8>, &'a mut V)>
-        where
-            'b: 'a,
+    where
+        'b: 'a,
     {
         self.tree
             .iter_prefix_mut(prefix)
             .into_iter()
-            .flat_map(move |(prefix_len, nodes)| IterMut::new(nodes, Vec::from(&prefix[..prefix_len])))
+            .flat_map(move |(prefix_len, nodes)| {
+                IterMut::new(nodes, Vec::from(&prefix[..prefix_len]))
+            })
     }
 
     /// Gets an iterator over the keys of this map, in sorted order.
@@ -547,10 +549,7 @@ pub struct IterMut<'a, V: 'a> {
 }
 impl<'a, V: 'a> IterMut<'a, V> {
     fn new(nodes: tree::NodesMut<'a, V>, key: Vec<u8>) -> Self {
-        Self {
-            nodes,
-            key,
-        }
+        Self { nodes, key }
     }
 }
 impl<'a, V: 'a> Iterator for IterMut<'a, V> {

--- a/src/map.rs
+++ b/src/map.rs
@@ -559,7 +559,7 @@ impl<'a, V: 'a> Iterator for IterMut<'a, V> {
         while let Some((key_len, node)) = self.nodes.next() {
             self.key.truncate(key_len);
             self.key.extend(node.label());
-            if let Some(value) = node.take_value_mut() {
+            if let Some(value) = node.into_value_mut() {
                 return Some((self.key.clone(), value));
             }
         }

--- a/src/node.rs
+++ b/src/node.rs
@@ -286,6 +286,46 @@ impl<V> Node<V> {
         None
     }
 
+    pub(crate) fn proxy_mut(&mut self) -> NodeProxyMut<'_, V> {
+        let mut sibling_result = None;
+        let mut child_result = None;
+        let mut value_result = None;
+
+        if let Some(offset) = self.child_offset() {
+            if self.flags().contains(Flags::CHILD_INITIALIZED) {
+                unsafe {
+                    let child = self.ptr.offset(offset) as *mut Self;
+                    child_result.replace(&mut *child);
+                }
+            }
+        }
+
+        if let Some(offset) = self.sibling_offset() {
+            if self.flags().contains(Flags::SIBLING_INITIALIZED) {
+                unsafe {
+                    let sibling = self.ptr.offset(offset) as *mut Self;
+                    sibling_result.replace(&mut *sibling);
+                }
+            }
+        }
+
+        if let Some(offset) = self.value_offset() {
+            if self.flags().contains(Flags::VALUE_INITIALIZED) {
+                unsafe {
+                    let value = self.ptr.offset(offset) as *mut V;
+                    value_result.replace(&mut *value);
+                }
+            }
+        }
+
+        NodeProxyMut {
+            label: self.label(),
+            sibling: sibling_result,
+            child: child_result,
+            value: value_result
+        }
+    }
+
     /// Takes the value out of this node.
     pub fn take_value(&mut self) -> Option<V> {
         if let Some(offset) = self.value_offset() {
@@ -400,8 +440,44 @@ impl<V> Node<V> {
         }
     }
 
+    /// Gets a mutable iterator which traverses the nodes in this tree, in depth first order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use patricia_tree::PatriciaSet;
+    /// use patricia_tree::node::Node;
+    ///
+    /// let mut set = PatriciaSet::new();
+    /// set.insert("foo");
+    /// set.insert("bar");
+    /// set.insert("baz");
+    ///
+    /// let mut node = Node::from(set);
+    /// let nodes = node.iter_mut().map(|(level, node)| (level, node.label())).collect::<Vec<_>>();
+    /// assert_eq!(nodes,
+    ///            [
+    ///                (0, "".as_ref()),
+    ///                (1, "ba".as_ref()),
+    ///                (2, "r".as_ref()),
+    ///                (2, "z".as_ref()),
+    ///                (1, "foo".as_ref())
+    ///            ]);
+    /// ```
+    pub fn iter_mut(&mut self) -> IterMut<V> {
+        IterMut {
+            stack: vec![(0, self)],
+        }
+    }
+
     pub(crate) fn iter_descendant(&self) -> Iter<V> {
         Iter {
+            stack: vec![(0, self)],
+        }
+    }
+
+    pub(crate) fn iter_descendant_mut(&mut self) -> IterMut<V> {
+        IterMut {
             stack: vec![(0, self)],
         }
     }
@@ -482,6 +558,23 @@ impl<V> Node<V> {
         } else if common_prefix_len == 0 && self.label().get(0) <= key.get(0) {
             self.sibling()
                 .and_then(|sibling| sibling.get_prefix_node(next, offset))
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn get_prefix_node_mut(&mut self, key: &[u8], offset: usize) -> Option<(usize, &mut Self)> {
+        let common_prefix_len = self.skip_common_prefix(key);
+        let next = &key[common_prefix_len..];
+        if next.is_empty() {
+            Some((common_prefix_len, self))
+        } else if common_prefix_len == self.label().len() {
+            let offset = offset + common_prefix_len;
+            self.child_mut()
+                .and_then(|child| child.get_prefix_node_mut(next, offset))
+        } else if common_prefix_len == 0 && self.label().get(0) <= key.get(0) {
+            self.sibling_mut()
+                .and_then(|sibling| sibling.get_prefix_node_mut(next, offset))
         } else {
             None
         }
@@ -773,6 +866,57 @@ impl<'a, V: 'a> Iterator for Iter<'a, V> {
     }
 }
 
+/// A mutable iterator which traverses the nodes in a tree, in depth first order.
+///
+/// The first element of an item is the level of the traversing node.
+#[derive(Debug)]
+pub struct IterMut<'a, V: 'a> {
+    stack: Vec<(usize, &'a mut Node<V>)>,
+}
+
+/// A reference to an immediate node (without child or sibling) with its
+/// label and a mutable reference to its value, if present.
+pub struct NodeMutRef<'a, V: 'a> {
+    label: &'a [u8],
+    value: Option<&'a mut V>,
+}
+impl<'a, V: 'a> NodeMutRef<'a, V> {
+    /// Makes a new reference to a node's label and mutable value.
+    pub fn new(label: &'a [u8], value: Option<&'a mut V>) -> Self {
+        NodeMutRef { label, value }
+    }
+
+    /// Returns the label of the referenced node.
+    pub fn label(&self) -> &'a [u8] {
+        self.label
+    }
+
+    /// Returns the optional reference to the value stored within the referenced node.
+    pub fn take_value_mut(self) -> Option<&'a mut V> {
+        self.value
+    }
+}
+
+impl<'a, V: 'a> Iterator for IterMut<'a, V> {
+    type Item = (usize, NodeMutRef<'a, V>);
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some((level, node)) = self.stack.pop() {
+            let proxy = node.proxy_mut();
+            if level != 0 {
+                if let Some(sibling) = proxy.sibling {
+                    self.stack.push((level, sibling));
+                }
+            }
+            if let Some(child) = proxy.child {
+                self.stack.push((level + 1, child));
+            }
+            Some((level, NodeMutRef::new(proxy.label, proxy.value)))
+        } else {
+            None
+        }
+    }
+}
+
 /// An iterator over entries in that collects all values up to
 /// until the key stops matching.
 #[derive(Debug)]
@@ -829,6 +973,13 @@ impl<V> Iterator for IntoIter<V> {
             None
         }
     }
+}
+
+pub(crate) struct NodeProxyMut<'a, V> {
+    label: &'a [u8],
+    sibling: Option<&'a mut Node<V>>,
+    child: Option<&'a mut Node<V>>,
+    value: Option<&'a mut V>,
 }
 
 #[cfg(test)]

--- a/src/node.rs
+++ b/src/node.rs
@@ -323,7 +323,7 @@ impl<V> Node<V> {
             label: self.label(),
             sibling: sibling_result,
             child: child_result,
-            value: value_result
+            value: value_result,
         }
     }
 
@@ -564,7 +564,11 @@ impl<V> Node<V> {
         }
     }
 
-    pub(crate) fn get_prefix_node_mut(&mut self, key: &[u8], offset: usize) -> Option<(usize, &mut Self)> {
+    pub(crate) fn get_prefix_node_mut(
+        &mut self,
+        key: &[u8],
+        offset: usize,
+    ) -> Option<(usize, &mut Self)> {
         let common_prefix_len = self.skip_common_prefix(key);
         let next = &key[common_prefix_len..];
         if next.is_empty() {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,4 +1,4 @@
-use crate::node::{self, Node, NodeMutRef};
+use crate::node::{self, Node, NodeMut};
 
 #[derive(Debug, Clone)]
 pub struct PatriciaTree<V> {
@@ -152,7 +152,7 @@ pub struct NodesMut<'a, V: 'a> {
     label_lens: Vec<usize>,
 }
 impl<'a, V: 'a> Iterator for NodesMut<'a, V> {
-    type Item = (usize, NodeMutRef<'a, V>);
+    type Item = (usize, NodeMut<'a, V>);
     fn next(&mut self) -> Option<Self::Item> {
         if let Some((level, node)) = self.nodes.next() {
             self.label_lens.resize(level + 1, 0);

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,4 +1,4 @@
-use crate::node::{self, Node};
+use crate::node::{self, Node, NodeMutRef};
 
 #[derive(Debug, Clone)]
 pub struct PatriciaTree<V> {
@@ -49,6 +49,17 @@ impl<V> PatriciaTree<V> {
             None
         }
     }
+    pub fn iter_prefix_mut<'a, 'b>(&'a mut self, prefix: &'b [u8]) -> Option<(usize, NodesMut<V>)> {
+        if let Some((common_prefix_len, node)) = self.root.get_prefix_node_mut(prefix, 0) {
+            let nodes = NodesMut {
+                nodes: node.iter_descendant_mut(),
+                label_lens: Vec::new(),
+            };
+            Some((prefix.len() - common_prefix_len, nodes))
+        } else {
+            None
+        }
+    }
     pub(crate) fn common_prefixes<K>(&self, key: K) -> node::CommonPrefixesIter<K, V>
     where
         K: AsRef<[u8]>,
@@ -88,6 +99,12 @@ impl<V> PatriciaTree<V> {
             label_lens: Vec::new(),
         }
     }
+    pub fn nodes_mut(&mut self) -> NodesMut<V> {
+        NodesMut {
+            nodes: self.root.iter_mut(),
+            label_lens: Vec::new(),
+        }
+    }
     pub fn into_nodes(self) -> IntoNodes<V> {
         IntoNodes {
             nodes: self.root.into_iter(),
@@ -116,6 +133,26 @@ pub struct Nodes<'a, V: 'a> {
 }
 impl<'a, V: 'a> Iterator for Nodes<'a, V> {
     type Item = (usize, &'a Node<V>);
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some((level, node)) = self.nodes.next() {
+            self.label_lens.resize(level + 1, 0);
+            self.label_lens[level] = node.label().len();
+
+            let parent_key_len = self.label_lens.iter().take(level).sum();
+            Some((parent_key_len, node))
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct NodesMut<'a, V: 'a> {
+    nodes: node::IterMut<'a, V>,
+    label_lens: Vec<usize>,
+}
+impl<'a, V: 'a> Iterator for NodesMut<'a, V> {
+    type Item = (usize, NodeMutRef<'a, V>);
     fn next(&mut self) -> Option<Self::Item> {
         if let Some((level, node)) = self.nodes.next() {
             self.label_lens.resize(level + 1, 0);


### PR DESCRIPTION
Hello!

I was using the `patricia_tree` library and ran into issue that there was no `mut` version of the `iter_prefix` function. I've went on and implemented it and added a simple unit test to ensure that it iterates and you're able to mutable values.

Let me know if this looks good! Glad to help.