### PR TITLE
Remove `Patricia{Map,Set}::insert_str()` and add `StringPatricia{Map,Set}` instead

### DIFF
--- a/examples/insert_lines.rs
+++ b/examples/insert_lines.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use patricia_tree::BytesPatriciaSet;
+use patricia_tree::PatriciaSet;
 use std::collections::{BTreeSet, HashSet};
 use std::io::BufRead;
 
@@ -18,7 +18,7 @@ fn main() {
 
     match args.kind.as_str() {
         "patricia" => {
-            let mut set = BytesPatriciaSet::new();
+            let mut set = PatriciaSet::new();
             each_line(|line| {
                 set.insert(line);
             });

--- a/examples/insert_lines.rs
+++ b/examples/insert_lines.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use patricia_tree::PatriciaSet;
+use patricia_tree::BytesPatriciaSet;
 use std::collections::{BTreeSet, HashSet};
 use std::io::BufRead;
 
@@ -18,7 +18,7 @@ fn main() {
 
     match args.kind.as_str() {
         "patricia" => {
-            let mut set = PatriciaSet::new();
+            let mut set = BytesPatriciaSet::new();
             each_line(|line| {
                 set.insert(line);
             });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,9 +41,9 @@ mod node;
 mod serialization;
 mod tree;
 
-/// TODO
+/// This trait represents a bytes type that can be used as the key type of patricia trees.
 pub trait Bytes {
-    /// TODO
+    /// Borrowed type of this type.
     type Borrowed: ?Sized + BorrowedBytes + ToOwned<Owned = Self>;
 }
 
@@ -55,18 +55,20 @@ impl Bytes for String {
     type Borrowed = str;
 }
 
-/// TODO
+/// Borrowed type of [`Bytes`].
 pub trait BorrowedBytes {
-    /// TODO
+    /// Returns the byte representation of this instance.
     fn as_bytes(&self) -> &[u8];
 
-    /// TODO
+    /// Returns `true` if the given bytes is a valid representation of this type, otherwise `false`.
     fn is_valid_bytes(bytes: &[u8]) -> bool;
 
-    /// TODO
+    /// Converts the given bytes to an instance of this type.
+    ///
+    /// Caller can assume that `is_valid_bytes(bytes)` is `true`.
     fn from_bytes(bytes: &[u8]) -> &Self;
 
-    /// TODO
+    /// Returns a suffix of this instance not containing the common prefix with the given bytes.
     fn strip_common_prefix(&self, bytes: &[u8]) -> &Self;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,8 @@ extern crate bitflags;
 #[cfg(test)]
 extern crate rand;
 
-pub use map::PatriciaMap;
-pub use set::PatriciaSet;
+pub use map::{BytesPatriciaMap, PatriciaMap};
+pub use set::{BytesPatriciaSet, PatriciaSet};
 
 pub mod map;
 pub mod set;
@@ -44,9 +44,6 @@ mod tree;
 /// TODO
 pub trait Bytes {
     /// TODO
-    type Owned;
-
-    /// TODO
     fn as_bytes(&self) -> &[u8];
 
     /// TODO
@@ -56,15 +53,10 @@ pub trait Bytes {
     fn from_bytes(bytes: &[u8]) -> &Self;
 
     /// TODO
-    fn from_owned_bytes(bytes: Vec<u8>) -> Self::Owned;
-
-    /// TODO
-    fn strip_common_prefix<'a, 'b>(&'a self, bytes: &'b [u8]) -> (&'a Self, &'b [u8]);
+    fn strip_common_prefix(&self, bytes: &[u8]) -> &Self;
 }
 
 impl Bytes for [u8] {
-    type Owned = Vec<u8>;
-
     fn as_bytes(&self) -> &[u8] {
         self
     }
@@ -77,16 +69,70 @@ impl Bytes for [u8] {
         bytes
     }
 
-    fn from_owned_bytes(bytes: Vec<u8>) -> Self::Owned {
-        bytes
-    }
-
-    fn strip_common_prefix<'a, 'b>(&'a self, bytes: &'b [u8]) -> (&'a Self, &'b [u8]) {
+    fn strip_common_prefix(&self, bytes: &[u8]) -> &Self {
         let i = self
             .iter()
             .zip(bytes.iter())
             .take_while(|(a, b)| a == b)
             .count();
-        (&self[..i], &bytes[i..])
+        &self[i..]
     }
 }
+
+// pub(crate) fn insert_str(&mut self, key: &str, value: V) -> Option<V> {
+//     if self.label().get(0) > key.as_bytes().get(0) {
+//         let this = Node {
+//             ptr: self.ptr,
+//             _value: PhantomData,
+//         };
+//         let node = Node::new(key.as_bytes(), Some(value), None, Some(this));
+//         self.ptr = node.ptr;
+//         mem::forget(node);
+//         return None;
+//     }
+
+//     let common_prefix_len = self.skip_str_common_prefix(key);
+//     let next = &key[common_prefix_len..];
+//     let is_label_matched = common_prefix_len == self.label().len();
+//     if next.is_empty() {
+//         if is_label_matched {
+//             let old = self.take_value();
+//             self.set_value(value);
+//             old
+//         } else {
+//             self.split_at(common_prefix_len);
+//             self.set_value(value);
+//             None
+//         }
+//     } else if is_label_matched {
+//         if let Some(child) = self.child_mut() {
+//             return child.insert_str(next, value);
+//         }
+//         let child = Node::new(next.as_bytes(), Some(value), None, None);
+//         self.set_child(child);
+//         None
+//     } else if common_prefix_len == 0 {
+//         if let Some(sibling) = self.sibling_mut() {
+//             return sibling.insert_str(next, value);
+//         }
+//         let sibling = Node::new(next.as_bytes(), Some(value), None, None);
+//         self.set_sibling(sibling);
+//         None
+//     } else {
+//         self.split_at(common_prefix_len);
+//         assert_some!(self.child_mut()).insert_str(next, value);
+//         None
+//     }
+// }
+// fn skip_str_common_prefix(&self, key: &str) -> usize {
+//     for (i, c) in key.char_indices() {
+//         let n = c.len_utf8();
+//         if key.as_bytes()[i..i + n]
+//             .iter()
+//             .ne(self.label()[i..].iter().take(n))
+//         {
+//             return i;
+//         }
+//     }
+//     key.len()
+// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,3 +40,53 @@ mod node;
 #[cfg(feature = "serde")]
 mod serialization;
 mod tree;
+
+/// TODO
+pub trait Bytes {
+    /// TODO
+    type Owned;
+
+    /// TODO
+    fn as_bytes(&self) -> &[u8];
+
+    /// TODO
+    fn is_valid_bytes(bytes: &[u8]) -> bool;
+
+    /// TODO
+    fn from_bytes(bytes: &[u8]) -> &Self;
+
+    /// TODO
+    fn from_owned_bytes(bytes: Vec<u8>) -> Self::Owned;
+
+    /// TODO
+    fn strip_common_prefix<'a, 'b>(&'a self, bytes: &'b [u8]) -> (&'a Self, &'b [u8]);
+}
+
+impl Bytes for [u8] {
+    type Owned = Vec<u8>;
+
+    fn as_bytes(&self) -> &[u8] {
+        self
+    }
+
+    fn is_valid_bytes(_bytes: &[u8]) -> bool {
+        true
+    }
+
+    fn from_bytes(bytes: &[u8]) -> &Self {
+        bytes
+    }
+
+    fn from_owned_bytes(bytes: Vec<u8>) -> Self::Owned {
+        bytes
+    }
+
+    fn strip_common_prefix<'a, 'b>(&'a self, bytes: &'b [u8]) -> (&'a Self, &'b [u8]) {
+        let i = self
+            .iter()
+            .zip(bytes.iter())
+            .take_while(|(a, b)| a == b)
+            .count();
+        (&self[..i], &bytes[i..])
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,9 @@
 //! # Examples
 //!
 //! ```
-//! use patricia_tree::BytesPatriciaMap;
+//! use patricia_tree::PatriciaMap;
 //!
-//! let mut map = BytesPatriciaMap::new();
+//! let mut map = PatriciaMap::new();
 //! map.insert("foo", 1);
 //! map.insert("bar", 2);
 //! map.insert("baz", 3);
@@ -30,8 +30,8 @@ extern crate bitflags;
 #[cfg(test)]
 extern crate rand;
 
-pub use map::{BytesPatriciaMap, PatriciaMap, StringPatriciaMap};
-pub use set::{BytesPatriciaSet, PatriciaSet, StringPatriciaSet};
+pub use map::{GenericPatriciaMap, PatriciaMap, StringPatriciaMap};
+pub use set::{GenericPatriciaSet, PatriciaSet, StringPatriciaSet};
 
 pub mod map;
 pub mod set;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,9 @@
 //! # Examples
 //!
 //! ```
-//! use patricia_tree::PatriciaMap;
+//! use patricia_tree::BytesPatriciaMap;
 //!
-//! let mut map = PatriciaMap::new();
+//! let mut map = BytesPatriciaMap::new();
 //! map.insert("foo", 1);
 //! map.insert("bar", 2);
 //! map.insert("baz", 3);
@@ -44,6 +44,23 @@ mod tree;
 /// TODO
 pub trait Bytes {
     /// TODO
+    type Borrowed: ?Sized + BorrowedBytes;
+
+    /// TODO
+    fn from_borrowed(bytes: &Self::Borrowed) -> Self;
+}
+
+impl Bytes for Vec<u8> {
+    type Borrowed = [u8];
+
+    fn from_borrowed(bytes: &[u8]) -> Self {
+        bytes.to_owned()
+    }
+}
+
+/// TODO
+pub trait BorrowedBytes {
+    /// TODO
     fn as_bytes(&self) -> &[u8];
 
     /// TODO
@@ -56,7 +73,7 @@ pub trait Bytes {
     fn strip_common_prefix(&self, bytes: &[u8]) -> &Self;
 }
 
-impl Bytes for [u8] {
+impl BorrowedBytes for [u8] {
     fn as_bytes(&self) -> &[u8] {
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,8 @@ extern crate bitflags;
 #[cfg(test)]
 extern crate rand;
 
-pub use map::{BytesPatriciaMap, PatriciaMap};
-pub use set::{BytesPatriciaSet, PatriciaSet};
+pub use map::{BytesPatriciaMap, PatriciaMap, StringPatriciaMap};
+pub use set::{BytesPatriciaSet, PatriciaSet, StringPatriciaSet};
 
 pub mod map;
 pub mod set;
@@ -44,18 +44,15 @@ mod tree;
 /// TODO
 pub trait Bytes {
     /// TODO
-    type Borrowed: ?Sized + BorrowedBytes;
-
-    /// TODO
-    fn from_borrowed(bytes: &Self::Borrowed) -> Self;
+    type Borrowed: ?Sized + BorrowedBytes + ToOwned<Owned = Self>;
 }
 
 impl Bytes for Vec<u8> {
     type Borrowed = [u8];
+}
 
-    fn from_borrowed(bytes: &[u8]) -> Self {
-        bytes.to_owned()
-    }
+impl Bytes for String {
+    type Borrowed = str;
 }
 
 /// TODO
@@ -96,60 +93,29 @@ impl BorrowedBytes for [u8] {
     }
 }
 
-// pub(crate) fn insert_str(&mut self, key: &str, value: V) -> Option<V> {
-//     if self.label().get(0) > key.as_bytes().get(0) {
-//         let this = Node {
-//             ptr: self.ptr,
-//             _value: PhantomData,
-//         };
-//         let node = Node::new(key.as_bytes(), Some(value), None, Some(this));
-//         self.ptr = node.ptr;
-//         mem::forget(node);
-//         return None;
-//     }
+impl BorrowedBytes for str {
+    fn as_bytes(&self) -> &[u8] {
+        self.as_bytes()
+    }
 
-//     let common_prefix_len = self.skip_str_common_prefix(key);
-//     let next = &key[common_prefix_len..];
-//     let is_label_matched = common_prefix_len == self.label().len();
-//     if next.is_empty() {
-//         if is_label_matched {
-//             let old = self.take_value();
-//             self.set_value(value);
-//             old
-//         } else {
-//             self.split_at(common_prefix_len);
-//             self.set_value(value);
-//             None
-//         }
-//     } else if is_label_matched {
-//         if let Some(child) = self.child_mut() {
-//             return child.insert_str(next, value);
-//         }
-//         let child = Node::new(next.as_bytes(), Some(value), None, None);
-//         self.set_child(child);
-//         None
-//     } else if common_prefix_len == 0 {
-//         if let Some(sibling) = self.sibling_mut() {
-//             return sibling.insert_str(next, value);
-//         }
-//         let sibling = Node::new(next.as_bytes(), Some(value), None, None);
-//         self.set_sibling(sibling);
-//         None
-//     } else {
-//         self.split_at(common_prefix_len);
-//         assert_some!(self.child_mut()).insert_str(next, value);
-//         None
-//     }
-// }
-// fn skip_str_common_prefix(&self, key: &str) -> usize {
-//     for (i, c) in key.char_indices() {
-//         let n = c.len_utf8();
-//         if key.as_bytes()[i..i + n]
-//             .iter()
-//             .ne(self.label()[i..].iter().take(n))
-//         {
-//             return i;
-//         }
-//     }
-//     key.len()
-// }
+    fn is_valid_bytes(bytes: &[u8]) -> bool {
+        std::str::from_utf8(bytes).is_ok()
+    }
+
+    fn from_bytes(bytes: &[u8]) -> &Self {
+        std::str::from_utf8(bytes).expect("unreachable")
+    }
+
+    fn strip_common_prefix(&self, bytes: &[u8]) -> &Self {
+        for (i, c) in self.char_indices() {
+            let n = c.len_utf8();
+            if self.as_bytes()[i..i + n]
+                .iter()
+                .ne(bytes[i..].iter().take(n))
+            {
+                return &self[i..];
+            }
+        }
+        ""
+    }
+}

--- a/src/map.rs
+++ b/src/map.rs
@@ -7,26 +7,26 @@ use std::iter::FromIterator;
 use std::marker::PhantomData;
 
 /// TODO
-pub type BytesPatriciaMap<V> = PatriciaMap<Vec<u8>, V>;
+pub type PatriciaMap<V> = GenericPatriciaMap<Vec<u8>, V>;
 
 /// TODO
-pub type StringPatriciaMap<V> = PatriciaMap<String, V>;
+pub type StringPatriciaMap<V> = GenericPatriciaMap<String, V>;
 
 /// A map based on a patricia tree.
-pub struct PatriciaMap<K, V> {
+pub struct GenericPatriciaMap<K, V> {
     tree: PatriciaTree<V>,
     _key: PhantomData<K>,
 }
 
-impl<K, V> PatriciaMap<K, V> {
+impl<K, V> GenericPatriciaMap<K, V> {
     /// Makes a new empty `PatriciaMap` instance.
     ///
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaMap;
+    /// use patricia_tree::PatriciaMap;
     ///
-    /// let mut map = BytesPatriciaMap::new();
+    /// let mut map = PatriciaMap::new();
     /// assert!(map.is_empty());
     ///
     /// map.insert("foo", 10);
@@ -37,7 +37,7 @@ impl<K, V> PatriciaMap<K, V> {
     /// assert_eq!(map.get("foo"), None);
     /// ```
     pub fn new() -> Self {
-        PatriciaMap {
+        GenericPatriciaMap {
             tree: PatriciaTree::new(),
             _key: PhantomData,
         }
@@ -48,9 +48,9 @@ impl<K, V> PatriciaMap<K, V> {
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaMap;
+    /// use patricia_tree::PatriciaMap;
     ///
-    /// let mut map = BytesPatriciaMap::new();
+    /// let mut map = PatriciaMap::new();
     /// map.insert("foo", 1);
     /// map.clear();
     /// assert!(map.is_empty());
@@ -64,9 +64,9 @@ impl<K, V> PatriciaMap<K, V> {
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaMap;
+    /// use patricia_tree::PatriciaMap;
     ///
-    /// let mut map = BytesPatriciaMap::new();
+    /// let mut map = PatriciaMap::new();
     /// map.insert("foo", 1);
     /// map.insert("bar", 2);
     /// assert_eq!(map.len(), 2);
@@ -80,9 +80,9 @@ impl<K, V> PatriciaMap<K, V> {
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaMap;
+    /// use patricia_tree::PatriciaMap;
     ///
-    /// let mut map = BytesPatriciaMap::new();
+    /// let mut map = PatriciaMap::new();
     /// assert!(map.is_empty());
     ///
     /// map.insert("foo", 1);
@@ -113,15 +113,15 @@ impl<K, V> PatriciaMap<K, V> {
         self.tree.into_root()
     }
 }
-impl<K: Bytes, V> PatriciaMap<K, V> {
+impl<K: Bytes, V> GenericPatriciaMap<K, V> {
     /// Returns `true` if this map contains a value for the specified key.
     ///
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaMap;
+    /// use patricia_tree::PatriciaMap;
     ///
-    /// let mut map = BytesPatriciaMap::new();
+    /// let mut map = PatriciaMap::new();
     /// map.insert("foo", 1);
     /// assert!(map.contains_key("foo"));
     /// assert!(!map.contains_key("bar"));
@@ -135,9 +135,9 @@ impl<K: Bytes, V> PatriciaMap<K, V> {
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaMap;
+    /// use patricia_tree::PatriciaMap;
     ///
-    /// let mut map = BytesPatriciaMap::new();
+    /// let mut map = PatriciaMap::new();
     /// map.insert("foo", 1);
     /// assert_eq!(map.get("foo"), Some(&1));
     /// assert_eq!(map.get("bar"), None);
@@ -151,9 +151,9 @@ impl<K: Bytes, V> PatriciaMap<K, V> {
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaMap;
+    /// use patricia_tree::PatriciaMap;
     ///
-    /// let mut map = BytesPatriciaMap::new();
+    /// let mut map = PatriciaMap::new();
     /// map.insert("foo", 1);
     /// map.get_mut("foo").map(|v| *v = 2);
     /// assert_eq!(map.get("foo"), Some(&2));
@@ -168,9 +168,9 @@ impl<K: Bytes, V> PatriciaMap<K, V> {
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaMap;
+    /// use patricia_tree::PatriciaMap;
     ///
-    /// let mut map = BytesPatriciaMap::new();
+    /// let mut map = PatriciaMap::new();
     /// map.insert("foo", 1);
     /// map.insert("foobar", 2);
     /// assert_eq!(map.get_longest_common_prefix("fo"), None);
@@ -197,9 +197,9 @@ impl<K: Bytes, V> PatriciaMap<K, V> {
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaMap;
+    /// use patricia_tree::PatriciaMap;
     ///
-    /// let mut map = BytesPatriciaMap::new();
+    /// let mut map = PatriciaMap::new();
     /// assert_eq!(map.insert("foo", 1), None);
     /// assert_eq!(map.get("foo"), Some(&1));
     /// assert_eq!(map.insert("foo", 2), Some(1));
@@ -214,9 +214,9 @@ impl<K: Bytes, V> PatriciaMap<K, V> {
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaMap;
+    /// use patricia_tree::PatriciaMap;
     ///
-    /// let mut map = BytesPatriciaMap::new();
+    /// let mut map = PatriciaMap::new();
     /// map.insert("foo", 1);
     /// assert_eq!(map.remove("foo"), Some(1));
     /// assert_eq!(map.remove("foo"), None);
@@ -230,9 +230,9 @@ impl<K: Bytes, V> PatriciaMap<K, V> {
     /// # Example
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaMap;
+    /// use patricia_tree::PatriciaMap;
     ///
-    /// let mut t = BytesPatriciaMap::new();
+    /// let mut t = PatriciaMap::new();
     /// t.insert("a", vec!["a"]);
     /// t.insert("x", vec!["x"]);
     /// t.insert("ab", vec!["b"]);
@@ -261,8 +261,8 @@ impl<K: Bytes, V> PatriciaMap<K, V> {
     /// # Example
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaMap;
-    /// let mut t = BytesPatriciaMap::new();
+    /// use patricia_tree::PatriciaMap;
+    /// let mut t = PatriciaMap::new();
     /// t.insert("a", vec!["a"]);
     /// t.insert("x", vec!["x"]);
     /// t.insert("ab", vec!["b"]);
@@ -287,9 +287,9 @@ impl<K: Bytes, V> PatriciaMap<K, V> {
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaMap;
+    /// use patricia_tree::PatriciaMap;
     ///
-    /// let mut a = BytesPatriciaMap::new();
+    /// let mut a = PatriciaMap::new();
     /// a.insert("rust", 1);
     /// a.insert("ruby", 2);
     /// a.insert("bash", 3);
@@ -305,7 +305,7 @@ impl<K: Bytes, V> PatriciaMap<K, V> {
     /// ```
     pub fn split_by_prefix<Q: AsRef<K::Borrowed>>(&mut self, prefix: Q) -> Self {
         let subtree = self.tree.split_by_prefix(prefix.as_ref().as_bytes());
-        PatriciaMap {
+        GenericPatriciaMap {
             tree: subtree,
             _key: PhantomData,
         }
@@ -316,9 +316,9 @@ impl<K: Bytes, V> PatriciaMap<K, V> {
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaMap;
+    /// use patricia_tree::PatriciaMap;
     ///
-    /// let map: BytesPatriciaMap<_> =
+    /// let map: PatriciaMap<_> =
     ///     vec![("foo", 1), ("bar", 2), ("baz", 3)].into_iter().collect();
     /// assert_eq!(vec![(Vec::from("bar"), &2), ("baz".into(), &3), ("foo".into(), &1)],
     ///            map.iter().collect::<Vec<_>>());
@@ -332,9 +332,9 @@ impl<K: Bytes, V> PatriciaMap<K, V> {
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaMap;
+    /// use patricia_tree::PatriciaMap;
     ///
-    /// let mut map: BytesPatriciaMap<_> =
+    /// let mut map: PatriciaMap<_> =
     ///     vec![("foo", 1), ("bar", 2), ("baz", 3)].into_iter().collect();
     /// for (_, v) in map.iter_mut() {
     ///    *v += 10;
@@ -350,9 +350,9 @@ impl<K: Bytes, V> PatriciaMap<K, V> {
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaMap;
+    /// use patricia_tree::PatriciaMap;
     ///
-    /// let map: BytesPatriciaMap<_> =
+    /// let map: PatriciaMap<_> =
     ///     vec![("foo", 1), ("bar", 2), ("baz", 3)].into_iter().collect();
     /// assert_eq!(vec![Vec::from("bar"), "baz".into(), "foo".into()],
     ///            map.keys().collect::<Vec<_>>());
@@ -366,9 +366,9 @@ impl<K: Bytes, V> PatriciaMap<K, V> {
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaMap;
+    /// use patricia_tree::PatriciaMap;
     ///
-    /// let map: BytesPatriciaMap<_> =
+    /// let map: PatriciaMap<_> =
     ///     vec![("foo", 1), ("bar", 2), ("baz", 3)].into_iter().collect();
     /// assert_eq!(vec![2, 3, 1],
     ///            map.values().cloned().collect::<Vec<_>>());
@@ -384,9 +384,9 @@ impl<K: Bytes, V> PatriciaMap<K, V> {
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaMap;
+    /// use patricia_tree::PatriciaMap;
     ///
-    /// let mut map: BytesPatriciaMap<_> =
+    /// let mut map: PatriciaMap<_> =
     ///     vec![("foo", 1), ("bar", 2), ("baz", 3)].into_iter().collect();
     /// for v in map.values_mut() {
     ///     *v += 10;
@@ -400,15 +400,15 @@ impl<K: Bytes, V> PatriciaMap<K, V> {
         }
     }
 }
-impl<K: Bytes, V> PatriciaMap<K, V> {
+impl<K: Bytes, V> GenericPatriciaMap<K, V> {
     /// Gets an iterator over the entries having the given prefix of this map, sorted by key.
     ///
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaMap;
+    /// use patricia_tree::PatriciaMap;
     ///
-    /// let map: BytesPatriciaMap<_> =
+    /// let map: PatriciaMap<_> =
     ///     vec![("foo", 1), ("bar", 2), ("baz", 3)].into_iter().collect();
     /// assert_eq!(vec![(Vec::from("bar"), &2), ("baz".into(), &3)],
     ///            map.iter_prefix(b"ba").collect::<Vec<_>>());
@@ -433,9 +433,9 @@ impl<K: Bytes, V> PatriciaMap<K, V> {
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaMap;
+    /// use patricia_tree::PatriciaMap;
     ///
-    /// let mut map: BytesPatriciaMap<_> =
+    /// let mut map: PatriciaMap<_> =
     ///     vec![("foo", 1), ("bar", 2), ("baz", 3)].into_iter().collect();
     /// assert_eq!(vec![(Vec::from("bar"), &mut 2), ("baz".into(), &mut 3)],
     ///            map.iter_prefix_mut(b"ba").collect::<Vec<_>>());
@@ -455,7 +455,7 @@ impl<K: Bytes, V> PatriciaMap<K, V> {
             })
     }
 }
-impl<K: Bytes + fmt::Debug, V: fmt::Debug> fmt::Debug for PatriciaMap<K, V> {
+impl<K: Bytes + fmt::Debug, V: fmt::Debug> fmt::Debug for GenericPatriciaMap<K, V> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{{")?;
         for (i, (k, v)) in self.iter().enumerate() {
@@ -468,7 +468,7 @@ impl<K: Bytes + fmt::Debug, V: fmt::Debug> fmt::Debug for PatriciaMap<K, V> {
         Ok(())
     }
 }
-impl<K, V: Clone> Clone for PatriciaMap<K, V> {
+impl<K, V: Clone> Clone for GenericPatriciaMap<K, V> {
     fn clone(&self) -> Self {
         Self {
             tree: self.tree.clone(),
@@ -476,12 +476,12 @@ impl<K, V: Clone> Clone for PatriciaMap<K, V> {
         }
     }
 }
-impl<K, V> Default for PatriciaMap<K, V> {
+impl<K, V> Default for GenericPatriciaMap<K, V> {
     fn default() -> Self {
         Self::new()
     }
 }
-impl<K: Bytes, V> IntoIterator for PatriciaMap<K, V> {
+impl<K: Bytes, V> IntoIterator for GenericPatriciaMap<K, V> {
     type Item = (K, V);
     type IntoIter = IntoIter<K, V>;
     fn into_iter(self) -> Self::IntoIter {
@@ -492,7 +492,7 @@ impl<K: Bytes, V> IntoIterator for PatriciaMap<K, V> {
         }
     }
 }
-impl<K, Q, V> FromIterator<(Q, V)> for PatriciaMap<K, V>
+impl<K, Q, V> FromIterator<(Q, V)> for GenericPatriciaMap<K, V>
 where
     K: Bytes,
     Q: AsRef<K::Borrowed>,
@@ -501,14 +501,14 @@ where
     where
         I: IntoIterator<Item = (Q, V)>,
     {
-        let mut map = PatriciaMap::new();
+        let mut map = GenericPatriciaMap::new();
         for (k, v) in iter {
             map.insert(k, v);
         }
         map
     }
 }
-impl<K, Q, V> Extend<(Q, V)> for PatriciaMap<K, V>
+impl<K, Q, V> Extend<(Q, V)> for GenericPatriciaMap<K, V>
 where
     K: Bytes,
     Q: AsRef<K::Borrowed>,
@@ -697,7 +697,7 @@ mod tests {
             ("9", 9),
         ];
 
-        let mut map = BytesPatriciaMap::new();
+        let mut map = PatriciaMap::new();
         for &(ref k, v) in input.iter() {
             assert_eq!(map.insert(k, v), None);
             assert_eq!(map.get(k), Some(&v));
@@ -706,7 +706,7 @@ mod tests {
 
     #[test]
     fn debug_works() {
-        let map: BytesPatriciaMap<_> = vec![("foo", 1), ("bar", 2), ("baz", 3)]
+        let map: PatriciaMap<_> = vec![("foo", 1), ("bar", 2), ("baz", 3)]
             .into_iter()
             .collect();
         assert_eq!(
@@ -717,7 +717,7 @@ mod tests {
 
     #[test]
     fn clear_works() {
-        let mut map = BytesPatriciaMap::new();
+        let mut map = PatriciaMap::new();
         assert!(map.is_empty());
 
         map.insert("foo", 1);
@@ -729,7 +729,7 @@ mod tests {
 
     #[test]
     fn into_iter_works() {
-        let map: BytesPatriciaMap<_> = vec![("foo", 1), ("bar", 2), ("baz", 3)]
+        let map: PatriciaMap<_> = vec![("foo", 1), ("bar", 2), ("baz", 3)]
             .into_iter()
             .collect();
         assert_eq!(
@@ -740,7 +740,7 @@ mod tests {
 
     #[test]
     fn iter_mut_works() {
-        let mut map: BytesPatriciaMap<_> = vec![("foo", 1), ("bar", 2), ("baz", 3)]
+        let mut map: PatriciaMap<_> = vec![("foo", 1), ("bar", 2), ("baz", 3)]
             .into_iter()
             .collect();
 
@@ -761,7 +761,7 @@ mod tests {
         input.shuffle(&mut rand::thread_rng());
 
         // Insert
-        let mut map = input.iter().cloned().collect::<BytesPatriciaMap<_>>();
+        let mut map = input.iter().cloned().collect::<PatriciaMap<_>>();
         assert_eq!(map.len(), input.len());
 
         // Get
@@ -797,7 +797,7 @@ mod tests {
 
     #[test]
     fn test_common_word_prefixes() {
-        let mut t = BytesPatriciaMap::new();
+        let mut t = PatriciaMap::new();
         t.insert(".com.foo.", vec!["b"]);
         t.insert(".", vec!["a"]);
         t.insert(".com.foo.bar.", vec!["c"]);
@@ -816,7 +816,7 @@ mod tests {
 
     #[test]
     fn test_letter_prefixes() {
-        let mut t = BytesPatriciaMap::new();
+        let mut t = PatriciaMap::new();
         t.insert("x", vec!["x"]);
         t.insert("a", vec!["a"]);
         t.insert("ab", vec!["b"]);
@@ -835,7 +835,7 @@ mod tests {
 
     #[test]
     fn test_common_prefixes() {
-        let mut t = BytesPatriciaMap::new();
+        let mut t = PatriciaMap::new();
         t.insert("b", vec!["b"]);
         t.insert("a", vec!["a"]);
         t.insert("c", vec!["c"]);
@@ -856,7 +856,7 @@ mod tests {
         dbg!(&results);
         assert!(results.iter().eq(vec![&"a"].into_iter()));
 
-        let mut t = BytesPatriciaMap::new();
+        let mut t = PatriciaMap::new();
         t.insert("ab", vec!["b"]);
         t.insert("a", vec!["a"]);
         t.insert("abc", vec!["c"]);
@@ -872,7 +872,7 @@ mod tests {
 
         assert!(results.iter().eq(vec![&"a", &"b", &"c"].into_iter()));
 
-        let mut list = BytesPatriciaMap::new();
+        let mut list = PatriciaMap::new();
         list.insert(b".com.foocatnetworks.".as_ref(), vec![0 as u16]);
         list.insert(b".com.foocatnetworks.foo.".as_ref(), vec![1]);
         list.insert(b".com.foocatnetworks.foo.baz.".as_ref(), vec![2]);
@@ -893,7 +893,7 @@ mod tests {
     #[test]
     fn string_patricia_map_works() {
         // Insert as bytes.
-        let mut t = BytesPatriciaMap::new();
+        let mut t = PatriciaMap::new();
         t.insert("🌏🗻", ()); // [240,159,140,143,240,159,151,187]
         t.insert("🌏🍔", ()); // [240,159,140,143,240,159,141,148]
 
@@ -912,7 +912,7 @@ mod tests {
 
     #[test]
     fn issue21() {
-        let mut map = BytesPatriciaMap::new();
+        let mut map = PatriciaMap::new();
         map.insert("1", 0);
         map.insert("2", 0);
         map.remove("2");

--- a/src/map.rs
+++ b/src/map.rs
@@ -6,13 +6,13 @@ use std::fmt;
 use std::iter::FromIterator;
 use std::marker::PhantomData;
 
-/// TODO
+/// Patricia tree based map with [`Vec<u8>`] as key.
 pub type PatriciaMap<V> = GenericPatriciaMap<Vec<u8>, V>;
 
-/// TODO
+/// Patricia tree based map with [`String`] as key.
 pub type StringPatriciaMap<V> = GenericPatriciaMap<String, V>;
 
-/// A map based on a patricia tree.
+/// Patricia tree based map.
 pub struct GenericPatriciaMap<K, V> {
     tree: PatriciaTree<V>,
     _key: PhantomData<K>,

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,16 +1,21 @@
 //! A map based on a patricia tree.
 use crate::node::{self, Node};
 use crate::tree::{self, PatriciaTree};
+use crate::Bytes;
 use std::fmt;
 use std::iter::FromIterator;
+use std::marker::PhantomData;
+
+/// TODO
+pub type BytesPatriciaMap<V> = PatriciaMap<[u8], V>;
 
 /// A map based on a patricia tree.
-#[derive(Clone)]
-pub struct PatriciaMap<V> {
+pub struct PatriciaMap<K: ?Sized, V> {
     tree: PatriciaTree<V>,
+    _key: PhantomData<K>,
 }
 
-impl<V> PatriciaMap<V> {
+impl<K: ?Sized, V> PatriciaMap<K, V> {
     /// Makes a new empty `PatriciaMap` instance.
     ///
     /// # Examples
@@ -31,6 +36,7 @@ impl<V> PatriciaMap<V> {
     pub fn new() -> Self {
         PatriciaMap {
             tree: PatriciaTree::new(),
+            _key: PhantomData,
         }
     }
 
@@ -50,6 +56,61 @@ impl<V> PatriciaMap<V> {
         self.tree.clear();
     }
 
+    /// Returns the number of elements in this map.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use patricia_tree::PatriciaMap;
+    ///
+    /// let mut map = PatriciaMap::new();
+    /// map.insert("foo", 1);
+    /// map.insert("bar", 2);
+    /// assert_eq!(map.len(), 2);
+    /// ```
+    pub fn len(&self) -> usize {
+        self.tree.len()
+    }
+
+    /// Returns `true` if this map contains no elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use patricia_tree::PatriciaMap;
+    ///
+    /// let mut map = PatriciaMap::new();
+    /// assert!(map.is_empty());
+    ///
+    /// map.insert("foo", 1);
+    /// assert!(!map.is_empty());
+    ///
+    /// map.clear();
+    /// assert!(map.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    #[cfg(feature = "serde")]
+    pub(crate) fn from_node(node: Node<V>) -> Self {
+        Self {
+            tree: node.into(),
+            _key: PhantomData,
+        }
+    }
+
+    #[cfg(feature = "serde")]
+    pub(crate) fn as_node(&self) -> &Node<V> {
+        self.tree.root()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn into_node(self) -> Node<V> {
+        self.tree.into_root()
+    }
+}
+impl<K: ?Sized + Bytes, V> PatriciaMap<K, V> {
     /// Returns `true` if this map contains a value for the specified key.
     ///
     /// # Examples
@@ -62,8 +123,8 @@ impl<V> PatriciaMap<V> {
     /// assert!(map.contains_key("foo"));
     /// assert!(!map.contains_key("bar"));
     /// ```
-    pub fn contains_key<K: AsRef<[u8]>>(&self, key: K) -> bool {
-        self.tree.get(key).is_some()
+    pub fn contains_key<Q: AsRef<K>>(&self, key: Q) -> bool {
+        self.tree.get(key.as_ref().as_bytes()).is_some()
     }
 
     /// Returns a reference to the value corresponding to the key.
@@ -78,8 +139,8 @@ impl<V> PatriciaMap<V> {
     /// assert_eq!(map.get("foo"), Some(&1));
     /// assert_eq!(map.get("bar"), None);
     /// ```
-    pub fn get<K: AsRef<[u8]>>(&self, key: K) -> Option<&V> {
-        self.tree.get(key)
+    pub fn get<Q: AsRef<K>>(&self, key: Q) -> Option<&V> {
+        self.tree.get(key.as_ref().as_bytes())
     }
 
     /// Returns a mutable reference to the value corresponding to the key.
@@ -94,8 +155,8 @@ impl<V> PatriciaMap<V> {
     /// map.get_mut("foo").map(|v| *v = 2);
     /// assert_eq!(map.get("foo"), Some(&2));
     /// ```
-    pub fn get_mut<K: AsRef<[u8]>>(&mut self, key: K) -> Option<&mut V> {
-        self.tree.get_mut(key)
+    pub fn get_mut<Q: AsRef<K>>(&mut self, key: Q) -> Option<&mut V> {
+        self.tree.get_mut(key.as_ref().as_bytes())
     }
 
     /// Finds the longest common prefix of `key` and the keys in this map,
@@ -115,11 +176,14 @@ impl<V> PatriciaMap<V> {
     /// assert_eq!(map.get_longest_common_prefix("foobar"), Some(("foobar".as_bytes(), &2)));
     /// assert_eq!(map.get_longest_common_prefix("foobarbaz"), Some(("foobar".as_bytes(), &2)));
     /// ```
-    pub fn get_longest_common_prefix<'a, K>(&self, key: &'a K) -> Option<(&'a [u8], &V)>
+    pub fn get_longest_common_prefix<'a, Q>(&self, key: &'a Q) -> Option<(&'a K, &V)>
     where
-        K: AsRef<[u8]> + ?Sized,
+        Q: AsRef<K> + ?Sized,
     {
-        self.tree.get_longest_common_prefix(key.as_ref())
+        let (key, value) = self
+            .tree
+            .get_longest_common_prefix(key.as_ref().as_bytes())?;
+        Some((K::from_bytes(key), value))
     }
 
     /// Inserts a key-value pair into this map.
@@ -138,13 +202,8 @@ impl<V> PatriciaMap<V> {
     /// assert_eq!(map.insert("foo", 2), Some(1));
     /// assert_eq!(map.get("foo"), Some(&2));
     /// ```
-    pub fn insert<K: AsRef<[u8]>>(&mut self, key: K, value: V) -> Option<V> {
-        self.tree.insert(key, value)
-    }
-
-    /// As with [`PatriciaMap::insert()`] except for that this method regards UTF-8 character boundaries of the input key.
-    pub fn insert_str(&mut self, key: &str, value: V) -> Option<V> {
-        self.tree.insert_str(key, value)
+    pub fn insert<Q: AsRef<K>>(&mut self, key: Q, value: V) -> Option<V> {
+        self.tree.insert(key.as_ref(), value)
     }
 
     /// Removes a key from this map, returning the value at the key if the key was previously in it.
@@ -159,8 +218,8 @@ impl<V> PatriciaMap<V> {
     /// assert_eq!(map.remove("foo"), Some(1));
     /// assert_eq!(map.remove("foo"), None);
     /// ```
-    pub fn remove<K: AsRef<[u8]>>(&mut self, key: K) -> Option<V> {
-        self.tree.remove(key)
+    pub fn remove<Q: AsRef<K>>(&mut self, key: Q) -> Option<V> {
+        self.tree.remove(key.as_ref().as_bytes())
     }
 
     /// Returns an iterator that collects all entries in the map up to a certain key.
@@ -182,13 +241,14 @@ impl<V> PatriciaMap<V> {
     ///     .flatten()
     ///     .eq(vec![&"a", &"b", &"c", &"d"].into_iter()));
     /// ```
-    pub fn common_prefixes<'a, 'b>(&'a self, key: &'b [u8]) -> CommonPrefixesIter<'a, 'b, V>
+    pub fn common_prefixes<'a, 'b>(&'a self, key: &'b [u8]) -> CommonPrefixesIter<'a, 'b, K, V>
     where
         'a: 'b,
     {
         CommonPrefixesIter {
-            key,
+            key_bytes: key,
             iterator: self.tree.common_prefixes(key),
+            _key: PhantomData,
         }
     }
 
@@ -239,45 +299,12 @@ impl<V> PatriciaMap<V> {
     /// assert_eq!(a.keys().collect::<Vec<_>>(), [b"bash", b"ruby", b"rust"]);
     /// assert_eq!(b.keys().collect::<Vec<_>>(), [b"elixir", b"erlang"]);
     /// ```
-    pub fn split_by_prefix<K: AsRef<[u8]>>(&mut self, prefix: K) -> Self {
-        let subtree = self.tree.split_by_prefix(prefix);
-        PatriciaMap { tree: subtree }
-    }
-
-    /// Returns the number of elements in this map.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use patricia_tree::PatriciaMap;
-    ///
-    /// let mut map = PatriciaMap::new();
-    /// map.insert("foo", 1);
-    /// map.insert("bar", 2);
-    /// assert_eq!(map.len(), 2);
-    /// ```
-    pub fn len(&self) -> usize {
-        self.tree.len()
-    }
-
-    /// Returns `true` if this map contains no elements.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use patricia_tree::PatriciaMap;
-    ///
-    /// let mut map = PatriciaMap::new();
-    /// assert!(map.is_empty());
-    ///
-    /// map.insert("foo", 1);
-    /// assert!(!map.is_empty());
-    ///
-    /// map.clear();
-    /// assert!(map.is_empty());
-    /// ```
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
+    pub fn split_by_prefix<Q: AsRef<K>>(&mut self, prefix: Q) -> Self {
+        let subtree = self.tree.split_by_prefix(prefix.as_ref().as_bytes());
+        PatriciaMap {
+            tree: subtree,
+            _key: PhantomData,
+        }
     }
 
     /// Gets an iterator over the entries of this map, sorted by key.
@@ -292,7 +319,7 @@ impl<V> PatriciaMap<V> {
     /// assert_eq!(vec![(Vec::from("bar"), &2), ("baz".into(), &3), ("foo".into(), &1)],
     ///            map.iter().collect::<Vec<_>>());
     /// ```
-    pub fn iter(&self) -> Iter<V> {
+    pub fn iter(&self) -> Iter<K, V> {
         Iter::new(self.tree.nodes(), Vec::new())
     }
 
@@ -310,60 +337,8 @@ impl<V> PatriciaMap<V> {
     /// }
     /// assert_eq!(map.get("bar"), Some(&12));
     /// ```
-    pub fn iter_mut(&mut self) -> IterMut<V> {
+    pub fn iter_mut(&mut self) -> IterMut<K, V> {
         IterMut::new(self.tree.nodes_mut(), Vec::new())
-    }
-
-    /// Gets an iterator over the entries having the given prefix of this map, sorted by key.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use patricia_tree::PatriciaMap;
-    ///
-    /// let map: PatriciaMap<_> =
-    ///     vec![("foo", 1), ("bar", 2), ("baz", 3)].into_iter().collect();
-    /// assert_eq!(vec![(Vec::from("bar"), &2), ("baz".into(), &3)],
-    ///            map.iter_prefix(b"ba").collect::<Vec<_>>());
-    /// ```
-    pub fn iter_prefix<'a, 'b>(
-        &'a self,
-        prefix: &'b [u8],
-    ) -> impl 'a + Iterator<Item = (Vec<u8>, &'a V)>
-    where
-        'b: 'a,
-    {
-        self.tree
-            .iter_prefix(prefix)
-            .into_iter()
-            .flat_map(move |(prefix_len, nodes)| Iter::new(nodes, Vec::from(&prefix[..prefix_len])))
-    }
-
-    /// Gets a mutable iterator over the entries having the given prefix of this map, sorted by key.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use patricia_tree::PatriciaMap;
-    ///
-    /// let mut map: PatriciaMap<_> =
-    ///     vec![("foo", 1), ("bar", 2), ("baz", 3)].into_iter().collect();
-    /// assert_eq!(vec![(Vec::from("bar"), &mut 2), ("baz".into(), &mut 3)],
-    ///            map.iter_prefix_mut(b"ba").collect::<Vec<_>>());
-    /// ```
-    pub fn iter_prefix_mut<'a, 'b>(
-        &'a mut self,
-        prefix: &'b [u8],
-    ) -> impl 'a + Iterator<Item = (Vec<u8>, &'a mut V)>
-    where
-        'b: 'a,
-    {
-        self.tree
-            .iter_prefix_mut(prefix)
-            .into_iter()
-            .flat_map(move |(prefix_len, nodes)| {
-                IterMut::new(nodes, Vec::from(&prefix[..prefix_len]))
-            })
     }
 
     /// Gets an iterator over the keys of this map, in sorted order.
@@ -378,7 +353,7 @@ impl<V> PatriciaMap<V> {
     /// assert_eq!(vec![Vec::from("bar"), "baz".into(), "foo".into()],
     ///            map.keys().collect::<Vec<_>>());
     /// ```
-    pub fn keys(&self) -> Keys<V> {
+    pub fn keys(&self) -> Keys<K, V> {
         Keys(self.iter())
     }
 
@@ -420,23 +395,66 @@ impl<V> PatriciaMap<V> {
             nodes: self.tree.nodes(),
         }
     }
-
-    #[cfg(feature = "serde")]
-    pub(crate) fn from_node(node: Node<V>) -> Self {
-        Self { tree: node.into() }
+}
+impl<K: ?Sized + Bytes + ToOwned, V> PatriciaMap<K, V> {
+    /// Gets an iterator over the entries having the given prefix of this map, sorted by key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use patricia_tree::PatriciaMap;
+    ///
+    /// let map: PatriciaMap<_> =
+    ///     vec![("foo", 1), ("bar", 2), ("baz", 3)].into_iter().collect();
+    /// assert_eq!(vec![(Vec::from("bar"), &2), ("baz".into(), &3)],
+    ///            map.iter_prefix(b"ba").collect::<Vec<_>>());
+    /// ```
+    pub fn iter_prefix<'a, 'b>(
+        &'a self,
+        prefix: &'b K,
+    ) -> impl 'a + Iterator<Item = (K::Owned, &'a V)>
+    where
+        'b: 'a,
+    {
+        self.tree
+            .iter_prefix(prefix.as_bytes())
+            .into_iter()
+            .flat_map(move |(prefix_len, nodes)| {
+                Iter::<K, V>::new(nodes, Vec::from(&prefix.as_bytes()[..prefix_len]))
+            })
     }
 
-    #[cfg(feature = "serde")]
-    pub(crate) fn as_node(&self) -> &Node<V> {
-        self.tree.root()
-    }
-
-    #[cfg(test)]
-    pub(crate) fn into_node(self) -> Node<V> {
-        self.tree.into_root()
+    /// Gets a mutable iterator over the entries having the given prefix of this map, sorted by key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use patricia_tree::PatriciaMap;
+    ///
+    /// let mut map: PatriciaMap<_> =
+    ///     vec![("foo", 1), ("bar", 2), ("baz", 3)].into_iter().collect();
+    /// assert_eq!(vec![(Vec::from("bar"), &mut 2), ("baz".into(), &mut 3)],
+    ///            map.iter_prefix_mut(b"ba").collect::<Vec<_>>());
+    /// ```
+    pub fn iter_prefix_mut<'a, 'b>(
+        &'a mut self,
+        prefix: &'b K,
+    ) -> impl 'a + Iterator<Item = (K::Owned, &'a mut V)>
+    where
+        'b: 'a,
+    {
+        self.tree
+            .iter_prefix_mut(prefix.as_bytes())
+            .into_iter()
+            .flat_map(move |(prefix_len, nodes)| {
+                IterMut::<K, V>::new(nodes, Vec::from(&prefix.as_bytes()[..prefix_len]))
+            })
     }
 }
-impl<V: fmt::Debug> fmt::Debug for PatriciaMap<V> {
+impl<K: ?Sized + Bytes + ToOwned, V: fmt::Debug> fmt::Debug for PatriciaMap<K, V>
+where
+    K::Owned: fmt::Debug,
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{{")?;
         for (i, (k, v)) in self.iter().enumerate() {
@@ -449,28 +467,38 @@ impl<V: fmt::Debug> fmt::Debug for PatriciaMap<V> {
         Ok(())
     }
 }
-impl<V> Default for PatriciaMap<V> {
+impl<K: ?Sized, V: Clone> Clone for PatriciaMap<K, V> {
+    fn clone(&self) -> Self {
+        Self {
+            tree: self.tree.clone(),
+            _key: PhantomData,
+        }
+    }
+}
+impl<K: ?Sized, V> Default for PatriciaMap<K, V> {
     fn default() -> Self {
         Self::new()
     }
 }
-impl<V> IntoIterator for PatriciaMap<V> {
-    type Item = (Vec<u8>, V);
-    type IntoIter = IntoIter<V>;
+impl<K: ?Sized + Bytes + ToOwned, V> IntoIterator for PatriciaMap<K, V> {
+    type Item = (K::Owned, V);
+    type IntoIter = IntoIter<K, V>;
     fn into_iter(self) -> Self::IntoIter {
         IntoIter {
             nodes: self.tree.into_nodes(),
-            key: Vec::new(),
+            key_bytes: Vec::new(),
+            _key: PhantomData,
         }
     }
 }
-impl<K, V> FromIterator<(K, V)> for PatriciaMap<V>
+impl<K: ?Sized, Q, V> FromIterator<(Q, V)> for PatriciaMap<K, V>
 where
-    K: AsRef<[u8]>,
+    K: Bytes,
+    Q: AsRef<K>,
 {
     fn from_iter<I>(iter: I) -> Self
     where
-        I: IntoIterator<Item = (K, V)>,
+        I: IntoIterator<Item = (Q, V)>,
     {
         let mut map = PatriciaMap::new();
         for (k, v) in iter {
@@ -479,13 +507,14 @@ where
         map
     }
 }
-impl<K, V> Extend<(K, V)> for PatriciaMap<V>
+impl<K: ?Sized, Q, V> Extend<(Q, V)> for PatriciaMap<K, V>
 where
-    K: AsRef<[u8]>,
+    K: Bytes,
+    Q: AsRef<K>,
 {
     fn extend<I>(&mut self, iter: I)
     where
-        I: IntoIterator<Item = (K, V)>,
+        I: IntoIterator<Item = (Q, V)>,
     {
         for (k, v) in iter {
             self.insert(k, v);
@@ -495,29 +524,31 @@ where
 
 /// An iterator over a `PatriciaMap`'s entries.
 #[derive(Debug)]
-pub struct Iter<'a, V: 'a> {
+pub struct Iter<'a, K: ?Sized, V: 'a> {
     nodes: tree::Nodes<'a, V>,
-    key: Vec<u8>,
+    key_bytes: Vec<u8>,
     key_offset: usize,
+    _key: PhantomData<K>,
 }
-impl<'a, V: 'a> Iter<'a, V> {
+impl<'a, K: ?Sized, V: 'a> Iter<'a, K, V> {
     fn new(nodes: tree::Nodes<'a, V>, key: Vec<u8>) -> Self {
         let key_offset = key.len();
         Self {
             nodes,
-            key,
+            key_bytes: key,
             key_offset,
+            _key: PhantomData,
         }
     }
 }
-impl<'a, V: 'a> Iterator for Iter<'a, V> {
-    type Item = (Vec<u8>, &'a V);
+impl<'a, K: ?Sized + Bytes + ToOwned, V: 'a> Iterator for Iter<'a, K, V> {
+    type Item = (K::Owned, &'a V);
     fn next(&mut self) -> Option<Self::Item> {
         for (key_len, node) in &mut self.nodes {
-            self.key.truncate(self.key_offset + key_len);
-            self.key.extend(node.label());
+            self.key_bytes.truncate(self.key_offset + key_len);
+            self.key_bytes.extend(node.label());
             if let Some(value) = node.value() {
-                return Some((self.key.clone(), value));
+                return Some((K::from_bytes(&self.key_bytes).to_owned(), value));
             }
         }
         None
@@ -526,18 +557,19 @@ impl<'a, V: 'a> Iterator for Iter<'a, V> {
 
 /// An owning iterator over a `PatriciaMap`'s entries.
 #[derive(Debug)]
-pub struct IntoIter<V> {
+pub struct IntoIter<K: ?Sized, V> {
     nodes: tree::IntoNodes<V>,
-    key: Vec<u8>,
+    key_bytes: Vec<u8>,
+    _key: PhantomData<K>,
 }
-impl<V> Iterator for IntoIter<V> {
-    type Item = (Vec<u8>, V);
+impl<K: ?Sized + Bytes + ToOwned, V> Iterator for IntoIter<K, V> {
+    type Item = (K::Owned, V);
     fn next(&mut self) -> Option<Self::Item> {
         for (key_len, mut node) in &mut self.nodes {
-            self.key.truncate(key_len);
-            self.key.extend(node.label());
+            self.key_bytes.truncate(key_len);
+            self.key_bytes.extend(node.label());
             if let Some(value) = node.take_value() {
-                return Some((self.key.clone(), value));
+                return Some((K::from_bytes(&self.key_bytes).to_owned(), value));
             }
         }
         None
@@ -546,23 +578,28 @@ impl<V> Iterator for IntoIter<V> {
 
 /// A mutable iterator over a `PatriciaMap`'s entries.
 #[derive(Debug)]
-pub struct IterMut<'a, V: 'a> {
+pub struct IterMut<'a, K: ?Sized, V: 'a> {
     nodes: tree::NodesMut<'a, V>,
-    key: Vec<u8>,
+    key_bytes: Vec<u8>,
+    _key: PhantomData<K>,
 }
-impl<'a, V: 'a> IterMut<'a, V> {
+impl<'a, K: ?Sized, V: 'a> IterMut<'a, K, V> {
     fn new(nodes: tree::NodesMut<'a, V>, key: Vec<u8>) -> Self {
-        Self { nodes, key }
+        Self {
+            nodes,
+            key_bytes: key,
+            _key: PhantomData,
+        }
     }
 }
-impl<'a, V: 'a> Iterator for IterMut<'a, V> {
-    type Item = (Vec<u8>, &'a mut V);
+impl<'a, K: ?Sized + Bytes + ToOwned, V: 'a> Iterator for IterMut<'a, K, V> {
+    type Item = (K::Owned, &'a mut V);
     fn next(&mut self) -> Option<Self::Item> {
         for (key_len, node) in &mut self.nodes {
-            self.key.truncate(key_len);
-            self.key.extend(node.label());
+            self.key_bytes.truncate(key_len);
+            self.key_bytes.extend(node.label());
             if let Some(value) = node.into_value_mut() {
-                return Some((self.key.clone(), value));
+                return Some((K::from_bytes(&self.key_bytes).to_owned(), value));
             }
         }
         None
@@ -571,9 +608,9 @@ impl<'a, V: 'a> Iterator for IterMut<'a, V> {
 
 /// An iterator over a `PatriciaMap`'s keys.
 #[derive(Debug)]
-pub struct Keys<'a, V: 'a>(Iter<'a, V>);
-impl<'a, V: 'a> Iterator for Keys<'a, V> {
-    type Item = Vec<u8>;
+pub struct Keys<'a, K: ?Sized, V: 'a>(Iter<'a, K, V>);
+impl<'a, K: ?Sized + Bytes + ToOwned, V: 'a> Iterator for Keys<'a, K, V> {
+    type Item = K::Owned;
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next().map(|(k, _)| k)
     }
@@ -618,17 +655,18 @@ impl<'a, V: 'a> Iterator for ValuesMut<'a, V> {
 /// An iterator over entries in a `PatriciaMap` that share a common prefix with
 /// a given key.
 #[derive(Debug)]
-pub struct CommonPrefixesIter<'a, 'b, V> {
-    key: &'b [u8],
+pub struct CommonPrefixesIter<'a, 'b, K: ?Sized, V> {
+    key_bytes: &'b [u8],
     iterator: node::CommonPrefixesIter<'a, &'b [u8], V>,
+    _key: PhantomData<K>,
 }
-impl<'a, 'b, V> Iterator for CommonPrefixesIter<'a, 'b, V> {
-    type Item = (&'b [u8], &'a V);
+impl<'a, 'b, K: 'b + ?Sized + Bytes, V> Iterator for CommonPrefixesIter<'a, 'b, K, V> {
+    type Item = (&'b K, &'a V);
 
     fn next(&mut self) -> Option<Self::Item> {
         for (prefix_len, n) in self.iterator.by_ref() {
             if let Some(v) = n.value() {
-                return Some((&self.key[..prefix_len], v));
+                return Some((K::from_bytes(&self.key_bytes[..prefix_len]), v));
             }
         }
 
@@ -658,7 +696,7 @@ mod tests {
             ("9", 9),
         ];
 
-        let mut map = PatriciaMap::new();
+        let mut map = BytesPatriciaMap::new();
         for &(ref k, v) in input.iter() {
             assert_eq!(map.insert(k, v), None);
             assert_eq!(map.get(k), Some(&v));
@@ -667,7 +705,7 @@ mod tests {
 
     #[test]
     fn debug_works() {
-        let map: PatriciaMap<_> = vec![("foo", 1), ("bar", 2), ("baz", 3)]
+        let map: BytesPatriciaMap<_> = vec![("foo", 1), ("bar", 2), ("baz", 3)]
             .into_iter()
             .collect();
         assert_eq!(
@@ -678,7 +716,7 @@ mod tests {
 
     #[test]
     fn clear_works() {
-        let mut map = PatriciaMap::new();
+        let mut map = BytesPatriciaMap::new();
         assert!(map.is_empty());
 
         map.insert("foo", 1);
@@ -690,7 +728,7 @@ mod tests {
 
     #[test]
     fn into_iter_works() {
-        let map: PatriciaMap<_> = vec![("foo", 1), ("bar", 2), ("baz", 3)]
+        let map: BytesPatriciaMap<_> = vec![("foo", 1), ("bar", 2), ("baz", 3)]
             .into_iter()
             .collect();
         assert_eq!(
@@ -701,7 +739,7 @@ mod tests {
 
     #[test]
     fn iter_mut_works() {
-        let mut map: PatriciaMap<_> = vec![("foo", 1), ("bar", 2), ("baz", 3)]
+        let mut map: BytesPatriciaMap<_> = vec![("foo", 1), ("bar", 2), ("baz", 3)]
             .into_iter()
             .collect();
 
@@ -722,7 +760,7 @@ mod tests {
         input.shuffle(&mut rand::thread_rng());
 
         // Insert
-        let mut map = input.iter().cloned().collect::<PatriciaMap<_>>();
+        let mut map = input.iter().cloned().collect::<BytesPatriciaMap<_>>();
         assert_eq!(map.len(), input.len());
 
         // Get
@@ -758,7 +796,7 @@ mod tests {
 
     #[test]
     fn test_common_word_prefixes() {
-        let mut t = PatriciaMap::new();
+        let mut t = BytesPatriciaMap::new();
         t.insert(".com.foo.", vec!["b"]);
         t.insert(".", vec!["a"]);
         t.insert(".com.foo.bar.", vec!["c"]);
@@ -777,7 +815,7 @@ mod tests {
 
     #[test]
     fn test_letter_prefixes() {
-        let mut t = PatriciaMap::new();
+        let mut t = BytesPatriciaMap::new();
         t.insert("x", vec!["x"]);
         t.insert("a", vec!["a"]);
         t.insert("ab", vec!["b"]);
@@ -796,7 +834,7 @@ mod tests {
 
     #[test]
     fn test_common_prefixes() {
-        let mut t = PatriciaMap::new();
+        let mut t = BytesPatriciaMap::new();
         t.insert("b", vec!["b"]);
         t.insert("a", vec!["a"]);
         t.insert("c", vec!["c"]);
@@ -817,7 +855,7 @@ mod tests {
         dbg!(&results);
         assert!(results.iter().eq(vec![&"a"].into_iter()));
 
-        let mut t = PatriciaMap::new();
+        let mut t = BytesPatriciaMap::new();
         t.insert("ab", vec!["b"]);
         t.insert("a", vec!["a"]);
         t.insert("abc", vec!["c"]);
@@ -833,7 +871,7 @@ mod tests {
 
         assert!(results.iter().eq(vec![&"a", &"b", &"c"].into_iter()));
 
-        let mut list = PatriciaMap::new();
+        let mut list = BytesPatriciaMap::new();
         list.insert(b".com.foocatnetworks.".as_ref(), vec![0 as u16]);
         list.insert(b".com.foocatnetworks.foo.".as_ref(), vec![1]);
         list.insert(b".com.foocatnetworks.foo.baz.".as_ref(), vec![2]);
@@ -851,29 +889,30 @@ mod tests {
         assert!(vec![0 as u16, 1, 2].into_iter().eq(results.into_iter()));
     }
 
-    #[test]
-    fn utf8_keys_works() {
-        // Insert as bytes.
-        let mut t = PatriciaMap::new();
-        t.insert("🌏🗻", ()); // [240,159,140,143,240,159,151,187]
-        t.insert("🌏🍔", ()); // [240,159,140,143,240,159,141,148]
+    // TODO
+    // #[test]
+    // fn utf8_keys_works() {
+    //     // Insert as bytes.
+    //     let mut t = BytesPatriciaMap::new();
+    //     t.insert("🌏🗻", ()); // [240,159,140,143,240,159,151,187]
+    //     t.insert("🌏🍔", ()); // [240,159,140,143,240,159,141,148]
 
-        let first_label = t.as_node().child().unwrap().label();
-        assert!(std::str::from_utf8(first_label).is_err());
-        assert_eq!(first_label, [240, 159, 140, 143, 240, 159]);
+    //     let first_label = t.as_node().child().unwrap().label();
+    //     assert!(std::str::from_utf8(first_label).is_err());
+    //     assert_eq!(first_label, [240, 159, 140, 143, 240, 159]);
 
-        // Insert as string.
-        let mut t = PatriciaMap::new();
-        t.insert_str("🌏🗻", ());
-        t.insert_str("🌏🍔", ());
+    //     // Insert as string.
+    //     let mut t = BytesPatriciaMap::new();
+    //     t.insert_str("🌏🗻", ());
+    //     t.insert_str("🌏🍔", ());
 
-        let first_label = t.as_node().child().unwrap().label();
-        assert_eq!(std::str::from_utf8(first_label).ok(), Some("🌏"));
-    }
+    //     let first_label = t.as_node().child().unwrap().label();
+    //     assert_eq!(std::str::from_utf8(first_label).ok(), Some("🌏"));
+    // }
 
     #[test]
     fn issue21() {
-        let mut map = PatriciaMap::new();
+        let mut map = BytesPatriciaMap::new();
         map.insert("1", 0);
         map.insert("2", 0);
         map.remove("2");

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,5 +1,5 @@
 //! A node which represents a subtree of a patricia tree.
-use crate::Bytes;
+use crate::BorrowedBytes;
 use std::alloc::{alloc, dealloc, handle_alloc_error, Layout};
 use std::marker::PhantomData;
 use std::mem;
@@ -557,7 +557,7 @@ impl<V> Node<V> {
             None
         }
     }
-    pub(crate) fn insert<K: ?Sized + Bytes>(&mut self, key: &K, value: V) -> Option<V> {
+    pub(crate) fn insert<K: ?Sized + BorrowedBytes>(&mut self, key: &K, value: V) -> Option<V> {
         if self.label().first() > key.as_bytes().first() {
             let this = Node {
                 ptr: self.ptr,

--- a/src/node.rs
+++ b/src/node.rs
@@ -895,7 +895,7 @@ impl<V> Iterator for IntoIter<V> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::BytesPatriciaSet;
+    use crate::PatriciaSet;
     use std::str;
 
     #[test]
@@ -934,7 +934,7 @@ mod tests {
 
     #[test]
     fn ietr_works() {
-        let mut set = BytesPatriciaSet::new();
+        let mut set = PatriciaSet::new();
         set.insert("foo");
         set.insert("bar");
         set.insert("baz");
@@ -958,7 +958,7 @@ mod tests {
 
     #[test]
     fn iter_mut_works() {
-        let mut set = BytesPatriciaSet::new();
+        let mut set = PatriciaSet::new();
         set.insert("foo");
         set.insert("bar");
         set.insert("baz");
@@ -996,7 +996,7 @@ mod tests {
     fn reclaim_works() {
         let mut set = ["123", "123456", "123abc", "123def"]
             .iter()
-            .collect::<BytesPatriciaSet>();
+            .collect::<PatriciaSet>();
         assert_eq!(
             set_to_labels(&set),
             [(0, ""), (1, "123"), (2, "456"), (2, "abc"), (2, "def")]
@@ -1019,7 +1019,7 @@ mod tests {
     fn get_longest_common_prefix_works() {
         let set = ["123", "123456", "1234_67", "123abc", "123def"]
             .iter()
-            .collect::<BytesPatriciaSet>();
+            .collect::<PatriciaSet>();
 
         let lcp = |key| set.get_longest_common_prefix(key);
         assert_eq!(lcp(""), None);
@@ -1031,7 +1031,7 @@ mod tests {
         assert_eq!(lcp("123456789"), Some("123456".as_bytes()));
     }
 
-    fn set_to_labels(set: &BytesPatriciaSet) -> Vec<(usize, &str)> {
+    fn set_to_labels(set: &PatriciaSet) -> Vec<(usize, &str)> {
         set.as_node()
             .iter()
             .map(|(level, n)| (level, str::from_utf8(n.label()).unwrap()))

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -4,7 +4,7 @@ use serde::de::{Error, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::borrow::{Borrow, Cow};
 
-impl Serialize for PatriciaSet {
+impl<T: ?Sized> Serialize for PatriciaSet<T> {
     /// In order to serialize a [PatriciaSet], make sure you installed the crate
     /// with the feature `serde`.
     ///
@@ -23,7 +23,7 @@ impl Serialize for PatriciaSet {
     }
 }
 
-impl<T: Serialize> Serialize for PatriciaMap<T> {
+impl<K: ?Sized, V: Serialize> Serialize for PatriciaMap<K, V> {
     /// In order to serialize a [PatriciaMap], make sure you installed the crate
     /// with the feature `serde`.
     ///
@@ -71,7 +71,8 @@ impl<T: Serialize> Serialize for Node<T> {
     }
 }
 
-impl<'de> Deserialize<'de> for PatriciaSet {
+// TODO
+impl<'de, T: ?Sized> Deserialize<'de> for PatriciaSet<T> {
     /// In order to deserialize a [PatriciaSet], make sure you installed the crate
     /// with the feature `serde`.
     ///
@@ -90,7 +91,8 @@ impl<'de> Deserialize<'de> for PatriciaSet {
     }
 }
 
-impl<'de, T: Deserialize<'de>> Deserialize<'de> for PatriciaMap<T> {
+// TODO
+impl<'de, K: ?Sized, V: Deserialize<'de>> Deserialize<'de> for PatriciaMap<K, V> {
     /// In order to serialize a [PatriciaMap], make sure you installed the crate
     /// with the feature `serde`.
     ///
@@ -105,7 +107,7 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for PatriciaMap<T> {
     where
         D: Deserializer<'de>,
     {
-        Node::<T>::deserialize(deserializer).map(PatriciaMap::from_node)
+        Node::<V>::deserialize(deserializer).map(PatriciaMap::from_node)
     }
 }
 
@@ -232,7 +234,7 @@ impl<'de> Visitor<'de> for BytesVisitor {
 
 #[cfg(test)]
 mod tests {
-    use crate::PatriciaMap;
+    use crate::BytesPatriciaMap;
 
     #[test]
     fn serde_works() {
@@ -243,9 +245,9 @@ mod tests {
         ];
         input.sort();
 
-        let map: PatriciaMap<u32> = input.iter().cloned().collect();
+        let map: BytesPatriciaMap<u32> = input.iter().cloned().collect();
         let bytes = postcard::to_allocvec(&map).unwrap();
-        let map: PatriciaMap<u32> = postcard::from_bytes(&bytes).unwrap();
+        let map: BytesPatriciaMap<u32> = postcard::from_bytes(&bytes).unwrap();
 
         assert_eq!(map.len(), 3);
         assert_eq!(map.into_iter().collect::<Vec<_>>(), input);
@@ -260,9 +262,9 @@ mod tests {
         ];
         input.sort();
 
-        let map: PatriciaMap<u32> = input.iter().cloned().collect();
+        let map: BytesPatriciaMap<u32> = input.iter().cloned().collect();
         let json = serde_json::to_string(&map).unwrap();
-        let map: PatriciaMap<u32> = serde_json::from_str(&json).unwrap();
+        let map: BytesPatriciaMap<u32> = serde_json::from_str(&json).unwrap();
 
         assert_eq!(map.len(), 3);
         assert_eq!(map.into_iter().collect::<Vec<_>>(), input);
@@ -275,9 +277,9 @@ mod tests {
             .collect::<Vec<_>>();
         input.sort();
 
-        let map: PatriciaMap<u32> = input.iter().cloned().collect();
+        let map: BytesPatriciaMap<u32> = input.iter().cloned().collect();
         let bytes = postcard::to_allocvec(&map).unwrap();
-        let map: PatriciaMap<u32> = postcard::from_bytes(&bytes).unwrap();
+        let map: BytesPatriciaMap<u32> = postcard::from_bytes(&bytes).unwrap();
 
         assert_eq!(map.len(), 10000);
         assert_eq!(map.into_iter().collect::<Vec<_>>(), input);

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,8 +1,9 @@
 use crate::node::{Flags, Node};
-use crate::{PatriciaMap, PatriciaSet};
+use crate::{BorrowedBytes, PatriciaMap, PatriciaSet};
 use serde::de::{Error, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::borrow::{Borrow, Cow};
+use std::marker::PhantomData;
 
 impl<T> Serialize for PatriciaSet<T> {
     /// In order to serialize a [PatriciaSet], make sure you installed the crate
@@ -11,7 +12,7 @@ impl<T> Serialize for PatriciaSet<T> {
     /// For example, in your `Cargo.toml`:
     /// ```toml
     /// [dependencies]
-    /// patricia_tree = { version = "0.5.5", features = ["serde"] }
+    /// patricia_tree = { version = "*", features = ["serde"] }
     /// ```
     ///
     /// Read more about serialization / deserialization at the [serde] crate.
@@ -30,7 +31,7 @@ impl<K, V: Serialize> Serialize for PatriciaMap<K, V> {
     /// For example, in your `Cargo.toml`:
     /// ```toml
     /// [dependencies]
-    /// patricia_tree = { version = "0.5.5", features = ["serde"] }
+    /// patricia_tree = { version = "*", features = ["serde"] }
     /// ```
     ///
     /// Read more about serialization / deserialization at the [serde] crate.
@@ -71,15 +72,14 @@ impl<T: Serialize> Serialize for Node<T> {
     }
 }
 
-// TODO
-impl<'de, T> Deserialize<'de> for PatriciaSet<T> {
+impl<'de, T: crate::Bytes> Deserialize<'de> for PatriciaSet<T> {
     /// In order to deserialize a [PatriciaSet], make sure you installed the crate
     /// with the feature `serde`.
     ///
     /// For example, in your `Cargo.toml`:
     /// ```toml
     /// [dependencies]
-    /// patricia_tree = { version = "0.5.5", features = ["serde"] }
+    /// patricia_tree = { version = "*", features = ["serde"] }
     /// ```
     ///
     /// Read more about serialization / deserialization at the [serde] crate.
@@ -87,19 +87,18 @@ impl<'de, T> Deserialize<'de> for PatriciaSet<T> {
     where
         D: Deserializer<'de>,
     {
-        Node::deserialize(deserializer).map(PatriciaSet::from_node)
+        KeyAndNode::<T, ()>::deserialize(deserializer).map(|x| PatriciaSet::from_node(x.node))
     }
 }
 
-// TODO
-impl<'de, K, V: Deserialize<'de>> Deserialize<'de> for PatriciaMap<K, V> {
+impl<'de, K: crate::Bytes, V: Deserialize<'de>> Deserialize<'de> for PatriciaMap<K, V> {
     /// In order to serialize a [PatriciaMap], make sure you installed the crate
     /// with the feature `serde`.
     ///
     /// For example, in your `Cargo.toml`:
     /// ```toml
     /// [dependencies]
-    /// patricia_tree = { version = "0.5.5", features = ["serde"] }
+    /// patricia_tree = { version = "*", features = ["serde"] }
     /// ```
     ///
     /// Read more about serialization / deserialization at the [serde] crate.
@@ -107,16 +106,22 @@ impl<'de, K, V: Deserialize<'de>> Deserialize<'de> for PatriciaMap<K, V> {
     where
         D: Deserializer<'de>,
     {
-        Node::<V>::deserialize(deserializer).map(PatriciaMap::from_node)
+        KeyAndNode::<K, V>::deserialize(deserializer).map(|x| PatriciaMap::from_node(x.node))
     }
 }
 
-impl<'de, T: Deserialize<'de>> Deserialize<'de> for Node<T> {
+#[derive(Debug)]
+struct KeyAndNode<K, V> {
+    node: Node<V>,
+    _key: PhantomData<K>,
+}
+
+impl<'de, K: crate::Bytes, V: Deserialize<'de>> Deserialize<'de> for KeyAndNode<K, V> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let (tree_bytes, mut values): (Bytes<'de>, Vec<T>) =
+        let (tree_bytes, mut values): (Bytes<'de>, Vec<V>) =
             Deserialize::deserialize(deserializer)?;
         values.reverse();
         let mut tree_bytes = tree_bytes.0.as_ref();
@@ -134,8 +139,14 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for Node<T> {
             if tree_bytes.len() < label_len {
                 return Err(D::Error::custom("unexpected EOS"));
             }
-            let mut node = Node::<T>::new_for_decoding(flags, label_len as u8);
+            let mut node = Node::<V>::new_for_decoding(flags, label_len as u8);
             node.label_mut().copy_from_slice(&tree_bytes[..label_len]);
+            if !K::Borrowed::is_valid_bytes(node.label()) {
+                return Err(D::Error::custom(&format!(
+                    "malformed label bytes: {:?}",
+                    node.label()
+                )));
+            }
             tree_bytes = &tree_bytes[label_len..];
 
             if flags.contains(Flags::VALUE_INITIALIZED) {
@@ -166,7 +177,10 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for Node<T> {
                         return Err(D::Error::custom("invalid data"));
                     }
                 } else if level == 0 {
-                    return Ok(node);
+                    return Ok(KeyAndNode {
+                        node,
+                        _key: PhantomData,
+                    });
                 } else {
                     return Err(D::Error::custom("invalid data"));
                 }

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -4,7 +4,7 @@ use serde::de::{Error, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::borrow::{Borrow, Cow};
 
-impl<T: ?Sized> Serialize for PatriciaSet<T> {
+impl<T> Serialize for PatriciaSet<T> {
     /// In order to serialize a [PatriciaSet], make sure you installed the crate
     /// with the feature `serde`.
     ///
@@ -23,7 +23,7 @@ impl<T: ?Sized> Serialize for PatriciaSet<T> {
     }
 }
 
-impl<K: ?Sized, V: Serialize> Serialize for PatriciaMap<K, V> {
+impl<K, V: Serialize> Serialize for PatriciaMap<K, V> {
     /// In order to serialize a [PatriciaMap], make sure you installed the crate
     /// with the feature `serde`.
     ///
@@ -72,7 +72,7 @@ impl<T: Serialize> Serialize for Node<T> {
 }
 
 // TODO
-impl<'de, T: ?Sized> Deserialize<'de> for PatriciaSet<T> {
+impl<'de, T> Deserialize<'de> for PatriciaSet<T> {
     /// In order to deserialize a [PatriciaSet], make sure you installed the crate
     /// with the feature `serde`.
     ///
@@ -92,7 +92,7 @@ impl<'de, T: ?Sized> Deserialize<'de> for PatriciaSet<T> {
 }
 
 // TODO
-impl<'de, K: ?Sized, V: Deserialize<'de>> Deserialize<'de> for PatriciaMap<K, V> {
+impl<'de, K, V: Deserialize<'de>> Deserialize<'de> for PatriciaMap<K, V> {
     /// In order to serialize a [PatriciaMap], make sure you installed the crate
     /// with the feature `serde`.
     ///

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,11 +1,11 @@
 use crate::node::{Flags, Node};
-use crate::{BorrowedBytes, PatriciaMap, PatriciaSet};
+use crate::{BorrowedBytes, GenericPatriciaMap, GenericPatriciaSet};
 use serde::de::{Error, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::borrow::{Borrow, Cow};
 use std::marker::PhantomData;
 
-impl<T> Serialize for PatriciaSet<T> {
+impl<T> Serialize for GenericPatriciaSet<T> {
     /// In order to serialize a [PatriciaSet], make sure you installed the crate
     /// with the feature `serde`.
     ///
@@ -24,7 +24,7 @@ impl<T> Serialize for PatriciaSet<T> {
     }
 }
 
-impl<K, V: Serialize> Serialize for PatriciaMap<K, V> {
+impl<K, V: Serialize> Serialize for GenericPatriciaMap<K, V> {
     /// In order to serialize a [PatriciaMap], make sure you installed the crate
     /// with the feature `serde`.
     ///
@@ -72,7 +72,7 @@ impl<T: Serialize> Serialize for Node<T> {
     }
 }
 
-impl<'de, T: crate::Bytes> Deserialize<'de> for PatriciaSet<T> {
+impl<'de, T: crate::Bytes> Deserialize<'de> for GenericPatriciaSet<T> {
     /// In order to deserialize a [PatriciaSet], make sure you installed the crate
     /// with the feature `serde`.
     ///
@@ -87,11 +87,12 @@ impl<'de, T: crate::Bytes> Deserialize<'de> for PatriciaSet<T> {
     where
         D: Deserializer<'de>,
     {
-        KeyAndNode::<T, ()>::deserialize(deserializer).map(|x| PatriciaSet::from_node(x.node))
+        KeyAndNode::<T, ()>::deserialize(deserializer)
+            .map(|x| GenericPatriciaSet::from_node(x.node))
     }
 }
 
-impl<'de, K: crate::Bytes, V: Deserialize<'de>> Deserialize<'de> for PatriciaMap<K, V> {
+impl<'de, K: crate::Bytes, V: Deserialize<'de>> Deserialize<'de> for GenericPatriciaMap<K, V> {
     /// In order to serialize a [PatriciaMap], make sure you installed the crate
     /// with the feature `serde`.
     ///
@@ -106,7 +107,7 @@ impl<'de, K: crate::Bytes, V: Deserialize<'de>> Deserialize<'de> for PatriciaMap
     where
         D: Deserializer<'de>,
     {
-        KeyAndNode::<K, V>::deserialize(deserializer).map(|x| PatriciaMap::from_node(x.node))
+        KeyAndNode::<K, V>::deserialize(deserializer).map(|x| GenericPatriciaMap::from_node(x.node))
     }
 }
 
@@ -248,7 +249,7 @@ impl<'de> Visitor<'de> for BytesVisitor {
 
 #[cfg(test)]
 mod tests {
-    use crate::BytesPatriciaMap;
+    use crate::PatriciaMap;
 
     #[test]
     fn serde_works() {
@@ -259,9 +260,9 @@ mod tests {
         ];
         input.sort();
 
-        let map: BytesPatriciaMap<u32> = input.iter().cloned().collect();
+        let map: PatriciaMap<u32> = input.iter().cloned().collect();
         let bytes = postcard::to_allocvec(&map).unwrap();
-        let map: BytesPatriciaMap<u32> = postcard::from_bytes(&bytes).unwrap();
+        let map: PatriciaMap<u32> = postcard::from_bytes(&bytes).unwrap();
 
         assert_eq!(map.len(), 3);
         assert_eq!(map.into_iter().collect::<Vec<_>>(), input);
@@ -276,9 +277,9 @@ mod tests {
         ];
         input.sort();
 
-        let map: BytesPatriciaMap<u32> = input.iter().cloned().collect();
+        let map: PatriciaMap<u32> = input.iter().cloned().collect();
         let json = serde_json::to_string(&map).unwrap();
-        let map: BytesPatriciaMap<u32> = serde_json::from_str(&json).unwrap();
+        let map: PatriciaMap<u32> = serde_json::from_str(&json).unwrap();
 
         assert_eq!(map.len(), 3);
         assert_eq!(map.into_iter().collect::<Vec<_>>(), input);
@@ -291,9 +292,9 @@ mod tests {
             .collect::<Vec<_>>();
         input.sort();
 
-        let map: BytesPatriciaMap<u32> = input.iter().cloned().collect();
+        let map: PatriciaMap<u32> = input.iter().cloned().collect();
         let bytes = postcard::to_allocvec(&map).unwrap();
-        let map: BytesPatriciaMap<u32> = postcard::from_bytes(&bytes).unwrap();
+        let map: PatriciaMap<u32> = postcard::from_bytes(&bytes).unwrap();
 
         assert_eq!(map.len(), 10000);
         assert_eq!(map.into_iter().collect::<Vec<_>>(), input);

--- a/src/set.rs
+++ b/src/set.rs
@@ -9,6 +9,9 @@ use std::iter::FromIterator;
 /// TODO
 pub type BytesPatriciaSet = PatriciaSet<Vec<u8>>;
 
+/// TODO
+pub type StringPatriciaSet = PatriciaSet<String>;
+
 /// A set based on a patricia tree.
 #[derive(Default, Clone)]
 pub struct PatriciaSet<T> {

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,5 +1,5 @@
 //! A set based on a patricia tree.
-use crate::map::{self, PatriciaMap};
+use crate::map::{self, GenericPatriciaMap};
 #[cfg(any(feature = "serde", test))]
 use crate::node::Node;
 use crate::Bytes;
@@ -7,31 +7,31 @@ use std::fmt;
 use std::iter::FromIterator;
 
 /// TODO
-pub type BytesPatriciaSet = PatriciaSet<Vec<u8>>;
+pub type PatriciaSet = GenericPatriciaSet<Vec<u8>>;
 
 /// TODO
-pub type StringPatriciaSet = PatriciaSet<String>;
+pub type StringPatriciaSet = GenericPatriciaSet<String>;
 
 /// A set based on a patricia tree.
 #[derive(Default, Clone)]
-pub struct PatriciaSet<T> {
-    map: PatriciaMap<T, ()>,
+pub struct GenericPatriciaSet<T> {
+    map: GenericPatriciaMap<T, ()>,
 }
 
-impl<T> PatriciaSet<T> {
-    /// Makes a new empty `PatriciaSet` instance.
+impl<T> GenericPatriciaSet<T> {
+    /// Makes a new empty [`GenericPatriciaSet`] instance.
     ///
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaSet;
+    /// use patricia_tree::PatriciaSet;
     ///
-    /// let set = BytesPatriciaSet::new();
+    /// let set = PatriciaSet::new();
     /// assert!(set.is_empty());
     /// ```
     pub fn new() -> Self {
-        PatriciaSet {
-            map: PatriciaMap::new(),
+        GenericPatriciaSet {
+            map: GenericPatriciaMap::new(),
         }
     }
 
@@ -40,9 +40,9 @@ impl<T> PatriciaSet<T> {
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaSet;
+    /// use patricia_tree::PatriciaSet;
     ///
-    /// let mut set = BytesPatriciaSet::new();
+    /// let mut set = PatriciaSet::new();
     /// set.insert("foo");
     /// set.insert("bar");
     /// assert_eq!(set.len(), 2);
@@ -56,9 +56,9 @@ impl<T> PatriciaSet<T> {
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaSet;
+    /// use patricia_tree::PatriciaSet;
     ///
-    /// let mut set = BytesPatriciaSet::new();
+    /// let mut set = PatriciaSet::new();
     /// assert!(set.is_empty());
     ///
     /// set.insert("foo");
@@ -76,9 +76,9 @@ impl<T> PatriciaSet<T> {
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaSet;
+    /// use patricia_tree::PatriciaSet;
     ///
-    /// let mut set = BytesPatriciaSet::new();
+    /// let mut set = PatriciaSet::new();
     /// set.insert("foo");
     /// set.clear();
     /// assert!(set.is_empty());
@@ -90,7 +90,7 @@ impl<T> PatriciaSet<T> {
     #[cfg(feature = "serde")]
     pub(crate) fn from_node(node: Node<()>) -> Self {
         Self {
-            map: PatriciaMap::from_node(node),
+            map: GenericPatriciaMap::from_node(node),
         }
     }
 
@@ -104,15 +104,15 @@ impl<T> PatriciaSet<T> {
         self.map.into_node()
     }
 }
-impl<T: Bytes> PatriciaSet<T> {
+impl<T: Bytes> GenericPatriciaSet<T> {
     /// Returns `true` if this set contains a value.
     ///
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaSet;
+    /// use patricia_tree::PatriciaSet;
     ///
-    /// let mut set = BytesPatriciaSet::new();
+    /// let mut set = PatriciaSet::new();
     /// set.insert("foo");
     /// assert!(set.contains("foo"));
     /// assert!(!set.contains("bar"));
@@ -126,9 +126,9 @@ impl<T: Bytes> PatriciaSet<T> {
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaSet;
+    /// use patricia_tree::PatriciaSet;
     ///
-    /// let mut set = BytesPatriciaSet::new();
+    /// let mut set = PatriciaSet::new();
     ///
     /// set.insert("foo");
     /// set.insert("foobar");
@@ -153,9 +153,9 @@ impl<T: Bytes> PatriciaSet<T> {
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaSet;
+    /// use patricia_tree::PatriciaSet;
     ///
-    /// let mut set = BytesPatriciaSet::new();
+    /// let mut set = PatriciaSet::new();
     /// assert!(set.insert("foo"));
     /// assert!(!set.insert("foo"));
     /// assert_eq!(set.len(), 1);
@@ -169,9 +169,9 @@ impl<T: Bytes> PatriciaSet<T> {
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaSet;
+    /// use patricia_tree::PatriciaSet;
     ///
-    /// let mut set = BytesPatriciaSet::new();
+    /// let mut set = PatriciaSet::new();
     /// set.insert("foo");
     /// assert_eq!(set.remove("foo"), true);
     /// assert_eq!(set.remove("foo"), false);
@@ -187,9 +187,9 @@ impl<T: Bytes> PatriciaSet<T> {
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaSet;
+    /// use patricia_tree::PatriciaSet;
     ///
-    /// let mut a = BytesPatriciaSet::new();
+    /// let mut a = PatriciaSet::new();
     /// a.insert("rust");
     /// a.insert("ruby");
     /// a.insert("python");
@@ -201,7 +201,7 @@ impl<T: Bytes> PatriciaSet<T> {
     /// assert_eq!(b.iter().collect::<Vec<_>>(), [b"ruby", b"rust"]);
     /// ```
     pub fn split_by_prefix<U: AsRef<T::Borrowed>>(&mut self, prefix: U) -> Self {
-        PatriciaSet {
+        GenericPatriciaSet {
             map: self.map.split_by_prefix(prefix),
         }
     }
@@ -211,9 +211,9 @@ impl<T: Bytes> PatriciaSet<T> {
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaSet;
+    /// use patricia_tree::PatriciaSet;
     ///
-    /// let mut set = BytesPatriciaSet::new();
+    /// let mut set = PatriciaSet::new();
     /// set.insert("foo");
     /// set.insert("bar");
     /// set.insert("baz");
@@ -224,15 +224,15 @@ impl<T: Bytes> PatriciaSet<T> {
         Iter(self.map.keys())
     }
 }
-impl<T: Bytes> PatriciaSet<T> {
+impl<T: Bytes> GenericPatriciaSet<T> {
     /// Gets an iterator over the contents having the given prefix of this set, in sorted order.
     ///
     /// # Examples
     ///
     /// ```
-    /// use patricia_tree::BytesPatriciaSet;
+    /// use patricia_tree::PatriciaSet;
     ///
-    /// let mut set = BytesPatriciaSet::new();
+    /// let mut set = PatriciaSet::new();
     /// set.insert("foo");
     /// set.insert("bar");
     /// set.insert("baz");
@@ -246,7 +246,7 @@ impl<T: Bytes> PatriciaSet<T> {
         self.map.iter_prefix(prefix).map(|(k, _)| k)
     }
 }
-impl<T: Bytes + fmt::Debug> fmt::Debug for PatriciaSet<T> {
+impl<T: Bytes + fmt::Debug> fmt::Debug for GenericPatriciaSet<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{{")?;
         for (i, t) in self.iter().enumerate() {
@@ -259,26 +259,26 @@ impl<T: Bytes + fmt::Debug> fmt::Debug for PatriciaSet<T> {
         Ok(())
     }
 }
-impl<T: Bytes> IntoIterator for PatriciaSet<T> {
+impl<T: Bytes> IntoIterator for GenericPatriciaSet<T> {
     type Item = T;
     type IntoIter = IntoIter<T>;
     fn into_iter(self) -> Self::IntoIter {
         IntoIter(self.map.into_iter())
     }
 }
-impl<T: Bytes, U: AsRef<T::Borrowed>> FromIterator<U> for PatriciaSet<T> {
+impl<T: Bytes, U: AsRef<T::Borrowed>> FromIterator<U> for GenericPatriciaSet<T> {
     fn from_iter<I>(iter: I) -> Self
     where
         I: IntoIterator<Item = U>,
     {
-        let mut set = PatriciaSet::new();
+        let mut set = GenericPatriciaSet::new();
         for t in iter {
             set.insert(t);
         }
         set
     }
 }
-impl<T: Bytes, U: AsRef<T::Borrowed>> Extend<U> for PatriciaSet<T> {
+impl<T: Bytes, U: AsRef<T::Borrowed>> Extend<U> for GenericPatriciaSet<T> {
     fn extend<I>(&mut self, iter: I)
     where
         I: IntoIterator<Item = U>,
@@ -315,7 +315,7 @@ mod tests {
 
     #[test]
     fn debug_works() {
-        let set: BytesPatriciaSet = vec!["foo", "bar", "baz"].into_iter().collect();
+        let set: PatriciaSet = vec!["foo", "bar", "baz"].into_iter().collect();
         assert_eq!(
             format!("{:?}", set),
             "{[98, 97, 114], [98, 97, 122], [102, 111, 111]}"
@@ -324,7 +324,7 @@ mod tests {
 
     #[test]
     fn clear_works() {
-        let mut set = BytesPatriciaSet::new();
+        let mut set = PatriciaSet::new();
         set.insert("foo");
         assert!(!set.is_empty());
 
@@ -334,7 +334,7 @@ mod tests {
 
     #[test]
     fn into_iter_works() {
-        let set: BytesPatriciaSet = vec!["foo", "bar", "baz"].into_iter().collect();
+        let set: PatriciaSet = vec!["foo", "bar", "baz"].into_iter().collect();
         assert_eq!(
             set.into_iter().collect::<Vec<_>>(),
             [Vec::from("bar"), "baz".into(), "foo".into()]
@@ -343,7 +343,7 @@ mod tests {
 
     #[test]
     fn split_by_prefix_works() {
-        let mut set: BytesPatriciaSet = vec!["foo", "bar", "baz"].into_iter().collect();
+        let mut set: PatriciaSet = vec!["foo", "bar", "baz"].into_iter().collect();
         let splitted_set = set.split_by_prefix("");
         assert!(set.is_empty());
         assert_eq!(
@@ -351,37 +351,37 @@ mod tests {
             [b"bar", b"baz", b"foo"]
         );
 
-        let mut set: BytesPatriciaSet = vec!["foo", "bar", "baz"].into_iter().collect();
+        let mut set: PatriciaSet = vec!["foo", "bar", "baz"].into_iter().collect();
         let splitted_set = set.split_by_prefix("f");
         assert_eq!(set.iter().collect::<Vec<_>>(), [b"bar", b"baz"]);
         assert_eq!(splitted_set.iter().collect::<Vec<_>>(), [b"foo"]);
 
-        let mut set: BytesPatriciaSet = vec!["foo", "bar", "baz"].into_iter().collect();
+        let mut set: PatriciaSet = vec!["foo", "bar", "baz"].into_iter().collect();
         let splitted_set = set.split_by_prefix("fo");
         assert_eq!(set.iter().collect::<Vec<_>>(), [b"bar", b"baz"]);
         assert_eq!(splitted_set.iter().collect::<Vec<_>>(), [b"foo"]);
 
-        let mut set: BytesPatriciaSet = vec!["foo", "bar", "baz"].into_iter().collect();
+        let mut set: PatriciaSet = vec!["foo", "bar", "baz"].into_iter().collect();
         let splitted_set = set.split_by_prefix("foo");
         assert_eq!(set.iter().collect::<Vec<_>>(), [b"bar", b"baz"]);
         assert_eq!(splitted_set.iter().collect::<Vec<_>>(), [b"foo"]);
 
-        let mut set: BytesPatriciaSet = vec!["foo", "bar", "baz"].into_iter().collect();
+        let mut set: PatriciaSet = vec!["foo", "bar", "baz"].into_iter().collect();
         let splitted_set = set.split_by_prefix("b");
         assert_eq!(set.iter().collect::<Vec<_>>(), [b"foo"]);
         assert_eq!(splitted_set.iter().collect::<Vec<_>>(), [b"bar", b"baz"]);
 
-        let mut set: BytesPatriciaSet = vec!["foo", "bar", "baz"].into_iter().collect();
+        let mut set: PatriciaSet = vec!["foo", "bar", "baz"].into_iter().collect();
         let splitted_set = set.split_by_prefix("ba");
         assert_eq!(set.iter().collect::<Vec<_>>(), [b"foo"]);
         assert_eq!(splitted_set.iter().collect::<Vec<_>>(), [b"bar", b"baz"]);
 
-        let mut set: BytesPatriciaSet = vec!["foo", "bar", "baz"].into_iter().collect();
+        let mut set: PatriciaSet = vec!["foo", "bar", "baz"].into_iter().collect();
         let splitted_set = set.split_by_prefix("bar");
         assert_eq!(set.iter().collect::<Vec<_>>(), [b"baz", b"foo"]);
         assert_eq!(splitted_set.iter().collect::<Vec<_>>(), [b"bar"]);
 
-        let mut set: BytesPatriciaSet = vec!["foo", "bar", "baz"].into_iter().collect();
+        let mut set: PatriciaSet = vec!["foo", "bar", "baz"].into_iter().collect();
         let mut splitted_set = set.split_by_prefix("baz");
         assert_eq!(set.iter().collect::<Vec<_>>(), [b"bar", b"foo"]);
         assert_eq!(splitted_set.iter().collect::<Vec<_>>(), [b"baz"]);
@@ -389,17 +389,17 @@ mod tests {
         splitted_set.insert("aaa");
         assert_eq!(splitted_set.iter().collect::<Vec<_>>(), [b"aaa", b"baz"]);
 
-        let mut set: BytesPatriciaSet = vec!["foo", "bar", "baz"].into_iter().collect();
+        let mut set: PatriciaSet = vec!["foo", "bar", "baz"].into_iter().collect();
         let splitted_set = set.split_by_prefix("bazz");
         assert_eq!(set.iter().collect::<Vec<_>>(), [b"bar", b"baz", b"foo"]);
         assert!(splitted_set.is_empty());
 
-        let mut set: BytesPatriciaSet = vec!["foo", "bar", "baz"].into_iter().collect();
+        let mut set: PatriciaSet = vec!["foo", "bar", "baz"].into_iter().collect();
         let splitted_set = set.split_by_prefix("for");
         assert_eq!(set.iter().collect::<Vec<_>>(), [b"bar", b"baz", b"foo"]);
         assert!(splitted_set.is_empty());
 
-        let mut set: BytesPatriciaSet = vec!["foo", "bar", "baz"].into_iter().collect();
+        let mut set: PatriciaSet = vec!["foo", "bar", "baz"].into_iter().collect();
         let splitted_set = set.split_by_prefix("qux");
         assert_eq!(set.iter().collect::<Vec<_>>(), [b"bar", b"baz", b"foo"]);
         assert!(splitted_set.is_empty());
@@ -407,7 +407,7 @@ mod tests {
 
     #[test]
     fn iter_prefix_works() {
-        fn assert_iter_prefix(set: &BytesPatriciaSet, prefix: &str) {
+        fn assert_iter_prefix(set: &PatriciaSet, prefix: &str) {
             let actual = set.iter_prefix(prefix.as_bytes()).collect::<Vec<_>>();
             let expected = set
                 .iter()
@@ -416,7 +416,7 @@ mod tests {
             assert_eq!(actual, expected);
         }
 
-        let set: BytesPatriciaSet = vec!["foo", "bar", "baz"].into_iter().collect();
+        let set: PatriciaSet = vec!["foo", "bar", "baz"].into_iter().collect();
         let prefixes = [
             "", "a", "b", "ba", "bar", "baz", "bax", "c", "f", "fo", "foo",
         ];
@@ -424,7 +424,7 @@ mod tests {
             assert_iter_prefix(&set, prefix);
         }
 
-        let set: BytesPatriciaSet = vec![
+        let set: PatriciaSet = vec![
             "JavaScript",
             "Python",
             "Java",

--- a/src/set.rs
+++ b/src/set.rs
@@ -6,18 +6,16 @@ use crate::Bytes;
 use std::fmt;
 use std::iter::FromIterator;
 
-/// TODO
+/// Patricia tree based set with [`Vec<u8>`] as key.
 pub type PatriciaSet = GenericPatriciaSet<Vec<u8>>;
 
-/// TODO
+/// Patricia tree based set with [`String`] as key.
 pub type StringPatriciaSet = GenericPatriciaSet<String>;
 
-/// A set based on a patricia tree.
-#[derive(Default, Clone)]
+/// Patricia tree based set.
 pub struct GenericPatriciaSet<T> {
     map: GenericPatriciaMap<T, ()>,
 }
-
 impl<T> GenericPatriciaSet<T> {
     /// Makes a new empty [`GenericPatriciaSet`] instance.
     ///
@@ -257,6 +255,18 @@ impl<T: Bytes + fmt::Debug> fmt::Debug for GenericPatriciaSet<T> {
         }
         write!(f, "}}")?;
         Ok(())
+    }
+}
+impl<T> Clone for GenericPatriciaSet<T> {
+    fn clone(&self) -> Self {
+        GenericPatriciaSet {
+            map: self.map.clone(),
+        }
+    }
+}
+impl<T> Default for GenericPatriciaSet<T> {
+    fn default() -> Self {
+        GenericPatriciaSet::new()
     }
 }
 impl<T: Bytes> IntoIterator for GenericPatriciaSet<T> {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,6 +1,6 @@
 use crate::{
     node::{self, Node, NodeMut},
-    Bytes,
+    BorrowedBytes,
 };
 
 #[derive(Debug, Clone)]
@@ -24,7 +24,7 @@ impl<V> PatriciaTree<V> {
     pub fn into_root(self) -> Node<V> {
         self.root
     }
-    pub fn insert<K: ?Sized + Bytes>(&mut self, key: &K, value: V) -> Option<V> {
+    pub fn insert<K: ?Sized + BorrowedBytes>(&mut self, key: &K, value: V) -> Option<V> {
         if let Some(old) = self.root.insert(key, value) {
             Some(old)
         } else {


### PR DESCRIPTION
Resolves #27.

This PR contains following changes:
- Add `Bytes` and `BorrowedBytes` traits that are used to represent map and set key types
- Add `GenericPatriciaMap<K: Bytes, V>` and `GenericPatriciaSet<K: Bytes>`
  - They are generalized versions of the previous `PatriciaMap<V>` and `PatriciaSet`
- `PatriciaMap<V>` and `PatriciaSet` are now defined as alias types as `GenericPatriciaMap<Vec<u8>, V> and `GenericPatriciaSet<Vec<u8>>` respectively
  - The newer types have compatibility with the older versions  except for the newer versions don't have the `insert_str()` method
- Add `StringPatriciaMap<V>` and `StringPatriciaSet` that are alias types defined as `GenericPatriciaMap<String, V>` and `GenericPatriciaSet<String>` respectively