### PR TITLE
Add `PatriciaMap::get_longest_common_prefix_mut` method

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -189,6 +189,35 @@ impl<K: Bytes, V> GenericPatriciaMap<K, V> {
         Some((K::Borrowed::from_bytes(key), value))
     }
 
+    /// Finds the longest common prefix of `key` and the keys in this map,
+    /// and returns a reference to the entry whose key matches the prefix.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use patricia_tree::PatriciaMap;
+    ///
+    /// let mut map = PatriciaMap::new();
+    /// map.insert("foo", 1);
+    /// map.insert("foobar", 2);
+    /// assert_eq!(map.get_longest_common_prefix_mut("fo"), None);
+    /// assert_eq!(map.get_longest_common_prefix_mut("foo"), Some(("foo".as_bytes(), &mut 1)));
+    /// *map.get_longest_common_prefix_mut("foo").unwrap().1 = 3;
+    /// assert_eq!(map.get_longest_common_prefix_mut("fooba"), Some(("foo".as_bytes(), &mut 3)));
+    /// assert_eq!(map.get_longest_common_prefix_mut("foobar"), Some(("foobar".as_bytes(), &mut 2)));
+    /// *map.get_longest_common_prefix_mut("foobar").unwrap().1 = 4;
+    /// assert_eq!(map.get_longest_common_prefix_mut("foobarbaz"), Some(("foobar".as_bytes(), &mut 4)));
+    /// ```
+    pub fn get_longest_common_prefix_mut<'a, Q>(&mut self, key: &'a Q) -> Option<(&'a K::Borrowed, &mut V)>
+        where
+            Q: ?Sized + AsRef<K::Borrowed>,
+    {
+        let (key, value) = self
+            .tree
+            .get_longest_common_prefix_mut(key.as_ref().as_bytes())?;
+        Some((K::Borrowed::from_bytes(key), value))
+    }
+
     /// Inserts a key-value pair into this map.
     ///
     /// If the map did not have this key present, `None` is returned.

--- a/src/map.rs
+++ b/src/map.rs
@@ -190,7 +190,7 @@ impl<K: Bytes, V> GenericPatriciaMap<K, V> {
     }
 
     /// Finds the longest common prefix of `key` and the keys in this map,
-    /// and returns a reference to the entry whose key matches the prefix.
+    /// and returns a mutable reference to the entry whose key matches the prefix.
     ///
     /// # Examples
     ///

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -43,6 +43,11 @@ impl<V> PatriciaTree<V> {
             .get_longest_common_prefix(key, 0)
             .map(|(n, v)| (&key[..n], v))
     }
+    pub fn get_longest_common_prefix_mut<'a>(&mut self, key: &'a [u8]) -> Option<(&'a [u8], &mut V)> {
+        self.root
+            .get_longest_common_prefix_mut(key, 0)
+            .map(|(n, v)| (&key[..n], v))
+    }
     pub fn iter_prefix<'a, 'b>(&'a self, prefix: &'b [u8]) -> Option<(usize, Nodes<V>)> {
         if let Some((common_prefix_len, node)) = self.root.get_prefix_node(prefix, 0) {
             let nodes = Nodes {


### PR DESCRIPTION
Necessary if you want to mutate the prefixed value and not copy the key.