### PR TITLE
feat!: use `Formatter::debug_{map,set}` instead of hand-written outer `Debug` structure

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -491,15 +491,7 @@ impl<K: Bytes, V> GenericPatriciaMap<K, V> {
 }
 impl<K: Bytes + fmt::Debug, V: fmt::Debug> fmt::Debug for GenericPatriciaMap<K, V> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{{")?;
-        for (i, (k, v)) in self.iter().enumerate() {
-            if i != 0 {
-                write!(f, ", ")?;
-            }
-            write!(f, "{:?}: {:?}", k, v)?;
-        }
-        write!(f, "}}")?;
-        Ok(())
+        f.debug_map().entries(self.iter()).finish()
     }
 }
 impl<K, V: Clone> Clone for GenericPatriciaMap<K, V> {

--- a/src/set.rs
+++ b/src/set.rs
@@ -246,15 +246,7 @@ impl<T: Bytes> GenericPatriciaSet<T> {
 }
 impl<T: Bytes + fmt::Debug> fmt::Debug for GenericPatriciaSet<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{{")?;
-        for (i, t) in self.iter().enumerate() {
-            if i != 0 {
-                write!(f, ", ")?;
-            }
-            write!(f, "{:?}", t)?;
-        }
-        write!(f, "}}")?;
-        Ok(())
+        f.debug_set().entries(self.iter()).finish()
     }
 }
 impl<T> Clone for GenericPatriciaSet<T> {


### PR DESCRIPTION
This actually supports pretty-printing with the alternate flag `:#`, which is surely intended.

It should be noted that pretty-printing can be significantly slower than using "plain" `Debug` printing. Performance-sensitive users that desire to keep the "fast" printing behavior should avoid specifying `{:#?}` for their `GenericPatriciaMap`s and `GenericPatriciaSet`s.