### PR TITLE
clippy lints

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -2,7 +2,6 @@ use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use patricia_tree::PatriciaSet;
 use rand::{Rng, seq::IndexedRandom};
 
-use core::hash;
 use std::{
     collections::{BTreeSet, HashSet},
     hint::black_box,

--- a/src/map.rs
+++ b/src/map.rs
@@ -367,10 +367,10 @@ impl<K: Bytes, V> GenericPatriciaMap<K, V> {
     ///     .flatten()
     ///     .eq(vec![&"a", &"b", &"c", &"d"].into_iter()));
     /// ```
-    pub fn common_prefix_values_owned<'a>(
-        &'a self,
+    pub fn common_prefix_values_owned(
+        &self,
         key: K,
-    ) -> impl Iterator<Item = &'a V> + use<'a, K, V>
+    ) -> impl Iterator<Item = &V> + use<'_, K, V>
     where
         K: AsRef<K::Borrowed>,
     {

--- a/src/node.rs
+++ b/src/node.rs
@@ -448,10 +448,10 @@ impl<V> Node<V> {
         }
     }
 
-    pub(crate) fn common_prefixes_owned<'a, K: Bytes>(
-        &'a self,
+    pub(crate) fn common_prefixes_owned<K: Bytes>(
+        &self,
         key: K,
-    ) -> CommonPrefixesIterOwned<'a, K, V> {
+    ) -> CommonPrefixesIterOwned<'_, K, V> {
         CommonPrefixesIterOwned {
             key,
             stack: vec![(0, self)],

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -96,10 +96,10 @@ impl<V> PatriciaTree<V> {
     {
         self.root.common_prefixes(key)
     }
-    pub(crate) fn common_prefixes_owned<'a, K>(
-        &'a self,
+    pub(crate) fn common_prefixes_owned<K>(
+        &self,
         key: K,
-    ) -> node::CommonPrefixesIterOwned<'a, K, V>
+    ) -> node::CommonPrefixesIterOwned<'_, K, V>
     where
         K: Bytes + AsRef<K::Borrowed>,
     {


### PR DESCRIPTION
I've got one more for you. I'm not sure why this doesn't trigger the clippy linter in the pipeline but in vscode the editor noticed `core::hash` was not being used and that some lifetimes could be elided so I let it auto-fix the warnings.